### PR TITLE
Use server slot metadata for mapping registry

### DIFF
--- a/rest_api/app.py
+++ b/rest_api/app.py
@@ -397,7 +397,12 @@ def health(x_api_key: Optional[str] = Header(None)):
 def list_devices(x_api_key: Optional[str] = Header(None)):
     require_key(x_api_key)
     with DEVICE_SCAN_LOCK:
-        return [DEV_META[s].model_dump() for s in sorted(DEV_META.keys())]
+        slots = sorted(DEV_META.keys())
+        return {
+            "devices": [DEV_META[s].model_dump() for s in slots],
+            "slots": slots,
+            "count": len(slots),
+        }
 
 @app.get("/modes")
 def list_modes(x_api_key: Optional[str] = Header(None)):

--- a/seva/adapters/device_rest.py
+++ b/seva/adapters/device_rest.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 import requests
 
+from seva.domain.mapping import extract_device_entries
 from seva.domain.ports import BoxId, DevicePort
 
 from .api_errors import (
@@ -56,9 +57,7 @@ class DeviceRestAdapter(DevicePort):
         resp = self._session(box_id).get(url)
         self._ensure_ok(resp, f"devices[{box_id}]")
         data = self._json_any(resp)
-        if not isinstance(data, list):
-            raise RuntimeError(f"devices[{box_id}]: expected list response")
-        return [entry for entry in data if isinstance(entry, dict)]
+        return [dict(entry) for entry in extract_device_entries(data)]
 
     def get_modes(self, box_id: BoxId) -> List[str]:
         cached = self._mode_list_cache.get(box_id)

--- a/seva/adapters/job_rest.py
+++ b/seva/adapters/job_rest.py
@@ -12,6 +12,11 @@ import requests
 # Domain Port
 from seva.domain.entities import ExperimentPlan
 from seva.domain.util import normalize_mode_name
+from seva.domain.mapping import (
+    build_slot_registry,
+    extract_device_entries,
+    extract_slot_labels,
+)
 from seva.domain.ports import JobPort, RunGroupId, BoxId
 
 from .http_client import HttpConfig, RetryingSession
@@ -81,27 +86,20 @@ class JobRestAdapter(JobPort):
     # ---------- Registry ----------
 
     def _build_registry(self) -> None:
-        """Build well_id <-> (box, slot) mapping using fixed box-local offsets.
-
-        Offsets per box letter: A:+0, B:+10, C:+20, D:+30. The well number is
-        `offset + slot_index` (slot_index is 1-based). Examples:
-        - slot01 on box A -> well A1
-        - slot01 on box B -> well B11
-        - slot10 on box D -> well D40
-        """
-        offsets = {"A": 0, "B": 10, "C": 20, "D": 30}
-        self.well_to_slot.clear()
-        self.slot_to_well.clear()
+        """Build well_id <-> (box, slot) mapping using server-reported slots."""
+        slots_by_box: Dict[BoxId, List[str]] = {}
         for box in self.box_order:
-            box_letter = str(box)[:1].upper()
-            if box_letter not in offsets:
-                raise ValueError(f"Unsupported box id '{box}': expected leading letter in {sorted(offsets)}")
-            offset = offsets[box_letter]
-            for slot in range(1, 11):
-                well_number = offset + slot
-                well_id = f"{box}{well_number}"
-                self.well_to_slot[well_id] = (box, slot)
-                self.slot_to_well[(box, slot)] = well_id
+            payload = self._fetch_devices_payload(box)
+            slots = extract_slot_labels(payload)
+            if not slots:
+                raise ValueError(f"No slots available for box '{box}'.")
+            slots_by_box[box] = slots
+
+        well_to_slot, slot_to_well = build_slot_registry(
+            self.box_order, slots_by_box
+        )
+        self.well_to_slot = well_to_slot
+        self.slot_to_well = slot_to_well
 
     # ---------- JobPort implementation ----------
 
@@ -118,19 +116,10 @@ class JobRestAdapter(JobPort):
         return data
 
     def list_devices(self, box_id: BoxId) -> List[Dict]:
-        session = self.sessions.get(box_id)
-        if session is None:
-            raise ValueError(f"No session configured for box '{box_id}'")
-        url = self._make_url(box_id, "/devices")
-        resp = session.get(url, timeout=self.cfg.request_timeout_s)
-        self._ensure_ok(resp, f"devices[{box_id}]")
-        data = self._json_any(resp)
-        if not isinstance(data, list):
-            raise RuntimeError(f"devices[{box_id}]: expected list response")
+        payload = self._fetch_devices_payload(box_id)
         cleaned: List[Dict[str, Any]] = []
-        for item in data:
-            if isinstance(item, dict):
-                cleaned.append(item)
+        for item in extract_device_entries(payload):
+            cleaned.append(dict(item))
         return cleaned
 
     def start_batch(self, plan: ExperimentPlan) -> Tuple[RunGroupId, Dict[BoxId, List[str]]]:
@@ -476,6 +465,16 @@ class JobRestAdapter(JobPort):
         if base.endswith("/"):
             base = base[:-1]
         return f"{base}{path}"
+
+    def _fetch_devices_payload(self, box_id: BoxId) -> Any:
+        """Fetch raw device payload for registry and device queries."""
+        session = self.sessions.get(box_id)
+        if session is None:
+            raise ValueError(f"No session configured for box '{box_id}'")
+        url = self._make_url(box_id, "/devices")
+        resp = session.get(url, timeout=self.cfg.request_timeout_s)
+        self._ensure_ok(resp, f"devices[{box_id}]")
+        return self._json_any(resp)
 
     def _slot_label(self, slot: int) -> str:
         return f"slot{slot:02d}"

--- a/seva/domain/mapping.py
+++ b/seva/domain/mapping.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+
+SlotRegistry = Dict[Tuple[str, int], str]
+WellRegistry = Dict[str, Tuple[str, int]]
+
+
+def extract_device_entries(devices_payload: Any) -> List[Mapping[str, Any]]:
+    """Normalize a /devices response into a list of device entries."""
+    if isinstance(devices_payload, dict):
+        entries = devices_payload.get("devices")
+    else:
+        entries = devices_payload
+    if not isinstance(entries, list):
+        raise RuntimeError("devices payload: expected list of device entries")
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def extract_slot_labels(devices_payload: Any) -> List[str]:
+    """Return slot labels from a /devices payload or device entries."""
+    slots: List[str] = []
+    if isinstance(devices_payload, dict):
+        raw_slots = devices_payload.get("slots")
+        if isinstance(raw_slots, list):
+            slots = [str(item) for item in raw_slots if str(item).strip()]
+    if not slots:
+        entries = extract_device_entries(devices_payload)
+        slots = [
+            str(entry.get("slot"))
+            for entry in entries
+            if isinstance(entry.get("slot"), str) and entry.get("slot").strip()
+        ]
+    seen = set()
+    deduped: List[str] = []
+    for slot in slots:
+        if slot in seen:
+            continue
+        seen.add(slot)
+        deduped.append(slot)
+    return deduped
+
+
+def parse_slot_number(slot_label: str) -> int:
+    """Parse slot label strings like ``slot01`` into integers."""
+    if not isinstance(slot_label, str) or not slot_label.strip():
+        raise ValueError("Slot label must be a non-empty string.")
+    match = re.match(r"^slot(\d+)$", slot_label.strip().lower())
+    if not match:
+        raise ValueError(f"Unsupported slot label '{slot_label}'.")
+    return int(match.group(1))
+
+
+def build_slot_registry(
+    box_order: Iterable[str],
+    slots_by_box: Mapping[str, Iterable[str]],
+) -> Tuple[WellRegistry, SlotRegistry]:
+    """Build bidirectional well/slot mappings based on server slot labels."""
+    well_to_slot: WellRegistry = {}
+    slot_to_well: SlotRegistry = {}
+    offset = 0
+
+    for box in box_order:
+        slots = list(slots_by_box.get(box) or [])
+        if not slots:
+            raise ValueError(f"No slots provided for box '{box}'.")
+        slot_numbers = sorted(parse_slot_number(slot) for slot in slots)
+        max_slot = max(slot_numbers)
+        for slot_num in slot_numbers:
+            well_number = offset + slot_num
+            well_id = f"{box}{well_number}"
+            key = (box, slot_num)
+            if well_id in well_to_slot or key in slot_to_well:
+                raise ValueError(
+                    f"Duplicate well mapping for box '{box}' slot {slot_num:02d}."
+                )
+            well_to_slot[well_id] = key
+            slot_to_well[key] = well_id
+        offset += max_slot
+
+    return well_to_slot, slot_to_well
+
+
+def normalize_slot_registry(raw_registry: Any) -> SlotRegistry:
+    """Validate and normalize a slot registry from an adapter."""
+    if not isinstance(raw_registry, Mapping):
+        return {}
+    normalized: SlotRegistry = {}
+    for key, value in raw_registry.items():
+        if (
+            isinstance(key, tuple)
+            and len(key) == 2
+            and isinstance(key[0], str)
+            and isinstance(key[1], int)
+            and isinstance(value, str)
+        ):
+            normalized[(key[0], key[1])] = value
+    return normalized
+
+
+def resolve_well_id(
+    slot_registry: Mapping[Tuple[str, int], str],
+    box: str,
+    slot_num: int,
+) -> Optional[str]:
+    """Resolve a well id for the given box/slot combination."""
+    well_id = slot_registry.get((box, slot_num))
+    if not well_id and isinstance(box, str) and box:
+        well_id = slot_registry.get((box[0].upper(), slot_num))
+    return well_id


### PR DESCRIPTION
### Motivation
- Consolidate well/slot mapping logic into a shared domain helper so adapters and use cases resolve wells consistently.
- Drive client-side well/slot registry from server-reported slot labels instead of hard-coded per-box offsets.
- Surface slot metadata in the REST API so the GUI can fetch the actual slot configuration (count and labels).

### Description
- Add a domain helper `seva/domain/mapping.py` providing `extract_device_entries`, `extract_slot_labels`, `parse_slot_number`, `build_slot_registry`, `normalize_slot_registry`, and `resolve_well_id` for normalizing `/devices` payloads and building registries.
- Update `seva/adapters/job_rest.py` to fetch `/devices` payloads via `_fetch_devices_payload`, use `extract_slot_labels` and `build_slot_registry` in `_build_registry`, and use `extract_device_entries` in `list_devices` so registry building is server-driven.
- Update `seva/usecases/download_group_results.py` to consume `normalize_slot_registry` and `resolve_well_id` when renaming `slotNN` directories to well IDs.
- Update `seva/adapters/device_rest.py` to use `extract_device_entries` for consistent `list_devices` parsing.
- Extend the server `/devices` endpoint in `rest_api/app.py` to return `{"devices": [...], "slots": [...], "count": ...}` so adapters can read slot lists directly.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a0fdd5408331bd2b4250f3085517)