### PR TITLE
Add group_id support for jobs and recovery in REST adapter

### DIFF
--- a/rest_api/app.py
+++ b/rest_api/app.py
@@ -190,6 +190,7 @@ class JobRequest (BaseModel):
     client_datetime: str = Field(..., description="Zeitstempel des Clients fuer Verzeichnis- und Dateinamen")
     run_name: Optional[str] = None
     folder_name: Optional[str] = None
+    group_id: Optional[str] = Field(default=None, description="Optionales Gruppen-Label fuer /jobs?group_id")
     make_plot: bool = True
 
 
@@ -915,7 +916,11 @@ def start_job(req: JobRequest, x_api_key: Optional[str] = Header(None)):
         run_dir.mkdir(parents=True, exist_ok=True)
         _record_run_directory(run_id, run_dir)
 
-        raw_group_id = _normalize_group_value(req.folder_name) or _normalize_group_value(req.subdir)
+        raw_group_id = (
+            _normalize_group_value(req.group_id)
+            or _normalize_group_value(req.folder_name)
+            or _normalize_group_value(req.subdir)
+        )
         storage_folder = storage_info.subdir
 
         # Für Kompatibilität: 'mode' = erster Modus, 'modes' vollständig


### PR DESCRIPTION
### Motivation
- Allow runs started as a logical group to be queried and recovered after a GUI or adapter restart using a stable group identifier.
- Ensure the server persists a provided group label so `/jobs?group_id=...` reliably filters related runs.

### Description
- Add optional `group_id` field to the `JobRequest` model so clients can provide a group identifier with `POST /jobs` using `JobRequest.group_id`.
- Persist a normalized group value into `JOB_GROUP_IDS` during `start_job`, falling back to `folder_name`/`subdir` when `group_id` is not provided.
- Update the GUI REST adapter to include `group_id` in the start payload when calling `POST /jobs` (send `group_id` from `PlanMeta`).
- Implement recovery logic in `JobRestAdapter.poll_group` which calls a new helper ` _recover_group_runs` that queries `GET /jobs?group_id=...` to rebuild `_groups` when the local mapping is empty.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729cc030bc833187d698c784773da7)