### PR TITLE
Add firmware flashing adapter/use-case, UI wiring and relax local .bin validation

### DIFF
--- a/seva/adapters/firmware_rest.py
+++ b/seva/adapters/firmware_rest.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+
+from seva.domain.ports import BoxId, FirmwarePort
+
+from .api_errors import (
+    ApiClientError,
+    ApiError,
+    ApiServerError,
+    build_error_message,
+    extract_error_code,
+    extract_error_hint,
+    parse_error_payload,
+)
+from .http_client import HttpConfig, RetryingSession
+
+
+class FirmwareRestAdapter(FirmwarePort):
+    """REST adapter for firmware flashing endpoints."""
+
+    def __init__(
+        self,
+        base_urls: Dict[BoxId, str],
+        *,
+        api_keys: Optional[Dict[BoxId, str]] = None,
+        request_timeout_s: int = 10,
+        retries: int = 2,
+    ) -> None:
+        if not base_urls:
+            raise ValueError("FirmwareRestAdapter requires at least one box URL")
+
+        self.base_urls = dict(base_urls)
+        self.api_keys = dict(api_keys or {})
+        self.cfg = HttpConfig(request_timeout_s=request_timeout_s, retries=retries)
+        self.sessions: Dict[BoxId, RetryingSession] = {
+            box: RetryingSession(self.api_keys.get(box), self.cfg)
+            for box in self.base_urls
+        }
+
+    def flash_firmware(self, box_id: BoxId, firmware_path: str | Path) -> Dict[str, Any]:
+        path = Path(firmware_path)
+        url = self._make_url(box_id, "/firmware/flash")
+        session = self._session(box_id)
+        with path.open("rb") as handle:
+            files = {"file": (path.name, handle, "application/octet-stream")}
+            resp = session.post_multipart(url, files=files, timeout=self.cfg.request_timeout_s)
+        self._ensure_ok(resp, f"flash_firmware[{box_id}]")
+        data = self._json_any(resp)
+        if isinstance(data, dict):
+            return dict(data)
+        return {"response": data}
+
+    # ------------------------------------------------------------------
+    def _session(self, box_id: BoxId) -> RetryingSession:
+        try:
+            return self.sessions[box_id]
+        except KeyError as exc:
+            raise ValueError(f"No session configured for box '{box_id}'") from exc
+
+    def _make_url(self, box_id: BoxId, path: str) -> str:
+        base = self.base_urls.get(box_id)
+        if not base:
+            raise ValueError(f"No base URL configured for box '{box_id}'")
+        if base.endswith("/"):
+            base = base[:-1]
+        return f"{base}{path}"
+
+    @staticmethod
+    def _ensure_ok(resp: requests.Response, ctx: str) -> None:
+        if 200 <= resp.status_code < 300:
+            return
+        status = resp.status_code
+        payload = parse_error_payload(resp)
+        message = build_error_message(ctx, status, payload)
+        code = extract_error_code(payload)
+        hint = extract_error_hint(payload)
+        if 400 <= status < 500:
+            raise ApiClientError(
+                message,
+                status=status,
+                code=code,
+                hint=hint,
+                payload=payload,
+                context=ctx,
+            )
+        if 500 <= status < 600:
+            raise ApiServerError(
+                message,
+                status=status,
+                payload=payload,
+                context=ctx,
+            )
+        raise ApiError(message, status=status, payload=payload, context=ctx)
+
+    @staticmethod
+    def _json_any(resp: requests.Response) -> Any:
+        try:
+            return resp.json()
+        except Exception:
+            snippet = getattr(resp, "text", "")[:400]
+            raise RuntimeError(f"Invalid JSON response: {snippet}")
+
+
+__all__ = ["FirmwareRestAdapter"]

--- a/seva/domain/ports.py
+++ b/seva/domain/ports.py
@@ -68,3 +68,9 @@ class StreamPort(Protocol):
     """Placeholder for SSE/WebSocket streaming (not implemented yet)."""
 
     def subscribe(self, run_group_id: RunGroupId): ...
+
+
+class FirmwarePort(Protocol):
+    """Firmware flashing operations exposed by the boxes."""
+
+    def flash_firmware(self, box_id: BoxId, firmware_path: str | Path) -> Dict[str, Any]: ...

--- a/seva/usecases/flash_firmware.py
+++ b/seva/usecases/flash_firmware.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from seva.domain.ports import BoxId, FirmwarePort, UseCaseError
+
+
+@dataclass
+class FlashFirmwareResult:
+    successes: Dict[BoxId, Dict[str, Any]] = field(default_factory=dict)
+    failures: Dict[BoxId, str] = field(default_factory=dict)
+
+
+@dataclass
+class FlashFirmware:
+    firmware_port: FirmwarePort
+
+    def __call__(self, *, box_ids: Iterable[BoxId], firmware_path: str | Path) -> FlashFirmwareResult:
+        boxes = [str(box_id) for box_id in box_ids if str(box_id).strip()]
+        if not boxes:
+            raise UseCaseError("FIRMWARE_NO_TARGETS", "No target boxes configured.")
+
+        path = Path(firmware_path).expanduser()
+        if not path.exists():
+            raise UseCaseError("FIRMWARE_NOT_FOUND", f"Firmware file not found: {path}")
+        if path.is_dir():
+            raise UseCaseError("FIRMWARE_INVALID", f"Firmware path is a directory: {path}")
+
+        result = FlashFirmwareResult()
+        for box_id in boxes:
+            try:
+                response = self.firmware_port.flash_firmware(box_id, path)
+            except Exception as exc:
+                result.failures[box_id] = str(exc)
+                continue
+            result.successes[box_id] = dict(response or {})
+
+        return result
+
+
+__all__ = ["FlashFirmware", "FlashFirmwareResult"]

--- a/seva/viewmodels/settings_vm.py
+++ b/seva/viewmodels/settings_vm.py
@@ -20,6 +20,7 @@ class SettingsConfig:
     poll_backoff_max_ms: int = 5000
     auto_download_on_complete: bool = True
     api_base_urls: Dict[BoxId, str] = field(default_factory=dict)
+    firmware_path: str = ""
 
 
 def _default_debug_logging() -> bool:
@@ -111,6 +112,14 @@ class SettingsVM:
     def api_base_urls(self, value: Mapping[BoxId, Any]) -> None:
         self.config = replace(self.config, api_base_urls=dict(value or {}))
 
+    @property
+    def firmware_path(self) -> str:
+        return self.config.firmware_path
+
+    @firmware_path.setter
+    def firmware_path(self, value: str) -> None:
+        self.config = replace(self.config, firmware_path=str(value or ""))
+
     # ------------------------------------------------------------------
     def is_valid(self) -> bool:
         return True
@@ -149,6 +158,9 @@ class SettingsVM:
         if "relay_port" in payload:
             self.relay_port = int(payload.get("relay_port") or 0)
 
+        if "firmware_path" in payload:
+            self.firmware_path = str(payload.get("firmware_path") or "")
+
     def to_dict(self) -> dict:
         snapshot = asdict(self.config)
         snapshot.update(
@@ -160,6 +172,7 @@ class SettingsVM:
                 "debug_logging": bool(self.debug_logging),
                 "relay_ip": self.relay_ip,
                 "relay_port": self.relay_port,
+                "firmware_path": self.firmware_path,
             }
         )
         return snapshot


### PR DESCRIPTION
### Motivation
- Add a full firmware flashing flow that uploads firmware to boxes via the existing REST API and surfaces results in the Settings UI.
- Avoid duplicating validation logic: rely on the server-side `.bin` checks already implemented in `rest_api/app.py` and remove local suffix enforcement.
- Provide robust HTTP multipart support and consistent API error handling when posting firmware files.
- No skills were used for this change.

### Description
- Introduce `FirmwareRestAdapter` (`seva/adapters/firmware_rest.py`) which posts multipart firmware uploads, parses JSON responses, and maps API errors to `ApiClientError`/`ApiServerError`.
- Extend the HTTP client with `post_multipart` (`seva/adapters/http_client.py`) and use `RetryingSession` for retries and timeouts.
- Add `FirmwarePort` to `seva/domain/ports.py` and implement the `FlashFirmware` use-case (`seva/usecases/flash_firmware.py`) that validates path existence and directories but no longer enforces a `.bin` suffix.
- Wire the adapter and use-case into `AppController` (`seva/app/controller.py`), add Settings UI handlers (`seva/app/main.py`) for browsing/flashing firmware, and persist `firmware_path` in `SettingsVM` (`seva/viewmodels/settings_vm.py`).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974176fba1c833185116fa06a7c8eb9)