### PR TITLE
Include API error hints in adapter messages

### DIFF
--- a/seva/adapters/api_errors.py
+++ b/seva/adapters/api_errors.py
@@ -91,8 +91,13 @@ def parse_error_payload(resp: Any) -> Any:
 
 def build_error_message(ctx: str, status: int, payload: Any) -> str:
     detail = _payload_detail(payload)
+    hint = extract_error_hint(payload)
+    if detail and hint and hint != detail:
+        return f"{ctx}: {detail} (HTTP {status}) Hint: {hint}"
     if detail:
         return f"{ctx}: {detail} (HTTP {status})"
+    if hint:
+        return f"{ctx}: {hint} (HTTP {status})"
     return f"{ctx}: HTTP {status}"
 
 


### PR DESCRIPTION
### Motivation
- Surface API `hint` payloads in formatted error messages so clients receive more actionable details (for example when the server returns hint-only responses or extra guidance). 

### Description
- Update `build_error_message` in `seva/adapters/api_errors.py` to call `extract_error_hint` and include the hint in the returned message when present, including cases where both a detail and a distinct hint exist, or where only a hint is available.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977ee981f108331a8809c8fea45b9a8)