### PR TITLE
Integrate standalone plotter and NAS setup launcher

### DIFF
--- a/seva/app/main.py
+++ b/seva/app/main.py
@@ -21,7 +21,8 @@ from .views.experiment_panel_view import ExperimentPanelView
 from .views.run_overview_view import RunOverviewView
 from .views.channel_activity_view import ChannelActivityView
 from .views.settings_dialog import SettingsDialog
-from .views.data_plotter import DataPlotter
+from .dataplotter_standalone import DataProcessingGUI
+from .nas_gui_smb import NASSetupGUI
 from .views.discovery_results_dialog import DiscoveryResultsDialog
 from .views.runs_panel_view import RunsPanelView
 
@@ -1024,6 +1025,9 @@ class App:
             else:
                 self.win.show_toast("Firmware flash completed.")
 
+        def handle_open_nas_setup() -> None:
+            NASSetupGUI(self.win)
+
         dlg = SettingsDialog(
             self.win,
             on_test_connection=handle_test_connection,
@@ -1031,6 +1035,7 @@ class App:
             on_browse_results_dir=handle_browse_results_dir,
             on_browse_firmware=handle_browse_firmware,
             on_discover_devices=lambda: self._on_discover_devices(dlg),
+            on_open_nas_setup=handle_open_nas_setup,
             on_save=self._on_settings_saved,
             on_flash_firmware=handle_flash_firmware,
             on_close=lambda: None,
@@ -1104,26 +1109,7 @@ class App:
         self.win.show_toast("Settings saved.")
 
     def _on_open_plotter(self) -> None:
-        dp = DataPlotter(
-            self.win,
-            on_fetch_data=lambda: self.win.show_toast("Fetch (not wired)"),
-            on_axes_changed=lambda x, y: self.win.show_toast(f"Axes: {x}/{y}"),
-            on_section_changed=lambda s: self.win.show_toast(f"Section: {s}"),
-            on_apply_ir=lambda rs: self.win.show_toast(f"Apply IR Rs={rs}"),
-            on_reset_ir=lambda: self.win.show_toast("Reset IR"),
-            on_export_csv=lambda: self.win.show_toast("Export CSV (not wired)"),
-            on_export_png=lambda: self.win.show_toast("Export PNG (not wired)"),
-            on_open_plot=lambda wid: self._open_plot_for_well(wid),
-            on_open_results_folder=lambda wid: self.win.show_toast(
-                f"Open folder for {wid}"
-            ),
-            on_toggle_include=lambda wid, inc: self.win.show_toast(
-                f"{'Include' if inc else 'Exclude'} {wid}"
-            ),
-            on_close=lambda: None,
-        )
-        selection_summary = ", ".join(sorted(self.plate_vm.get_selection())) or "-"
-        dp.set_run_info(self._active_group_id or "-", selection_summary)
+        DataProcessingGUI(self.win)
 
     def _on_download_group_results(self) -> None:
         group_id = self._active_group_id

--- a/seva/app/nas_gui_smb.py
+++ b/seva/app/nas_gui_smb.py
@@ -50,11 +50,18 @@ class NASApiAdapter:
         return r.json()
 
 
-class NASSetupGUI(tk.Tk):
-    def __init__(self):
-        super().__init__()
+class NASSetupGUI(tk.Toplevel):
+    def __init__(self, master: tk.Misc | None = None):
+        if master is None:
+            self._root = tk.Tk()
+            self._root.withdraw()
+            super().__init__(self._root)
+        else:
+            self._root = None
+            super().__init__(master)
         self.title("NAS Setup (SMB/CIFS)")
         self.geometry("560x480")
+        self.protocol("WM_DELETE_WINDOW", self._on_close)
 
         # API Verbindung
         frm_api = ttk.LabelFrame(self, text="API Verbindung")
@@ -193,6 +200,17 @@ class NASSetupGUI(tk.Tk):
     def _append(self, text: str):
         self.txt.insert("end", text + "\n")
         self.txt.see("end")
+
+    def _on_close(self):
+        try:
+            if self.winfo_exists():
+                self.destroy()
+        finally:
+            if self._root is not None:
+                try:
+                    self._root.destroy()
+                except tk.TclError:
+                    pass
 
 
 if __name__ == "__main__":

--- a/seva/app/views/settings_dialog.py
+++ b/seva/app/views/settings_dialog.py
@@ -25,6 +25,7 @@ class SettingsDialog(tk.Toplevel):
         on_browse_results_dir: OnVoid = None,
         on_browse_firmware: OnVoid = None,
         on_discover_devices: OnVoid = None,
+        on_open_nas_setup: OnVoid = None,
         on_save: OnSave = None,
         on_flash_firmware: OnVoid = None,
         on_close: OnVoid = None,
@@ -40,6 +41,7 @@ class SettingsDialog(tk.Toplevel):
         self._on_browse_results_dir = on_browse_results_dir
         self._on_browse_firmware = on_browse_firmware
         self._on_discover_devices = on_discover_devices
+        self._on_open_nas_setup = on_open_nas_setup
         self._on_save = on_save
         self._on_flash_firmware = on_flash_firmware
         self._on_close = on_close
@@ -169,9 +171,18 @@ class SettingsDialog(tk.Toplevel):
             command=lambda: self._safe(self._on_flash_firmware),
         ).grid(row=1, column=0, columnspan=3, sticky="w", pady=(6, 0))
 
+        # NAS group
+        nas = ttk.Labelframe(self, text="NAS")
+        nas.grid(row=5, column=0, sticky="ew", **pad)
+        ttk.Button(
+            nas,
+            text="Open NAS Setup…",
+            command=lambda: self._safe(self._on_open_nas_setup),
+        ).pack(side="left")
+
         # Flags
         flags = ttk.Frame(self)
-        flags.grid(row=5, column=0, sticky="ew", **pad)
+        flags.grid(row=6, column=0, sticky="ew", **pad)
         ttk.Checkbutton(
             flags,
             text="Auto-download results on completion",
@@ -186,7 +197,7 @@ class SettingsDialog(tk.Toplevel):
 
         # Footer
         footer = ttk.Frame(self)
-        footer.grid(row=6, column=0, sticky="ew", **pad)
+        footer.grid(row=7, column=0, sticky="ew", **pad)
         footer.columnconfigure(0, weight=1)
         self._btn_save = ttk.Button(footer, text="Save", command=self._emit_save)
         self._btn_save.pack(side="right", padx=(0, 6))


### PR DESCRIPTION
### Motivation
- Wire the existing standalone `dataplotter_standalone.py` and `nas_gui_smb.py` into the SEVA GUI so they can be launched from the main app with a button click, without changing usecases or heavy refactors.
- Keep the standalone implementations intact and callable directly from the UI, and place the NAS setup inside the Settings dialog for discoverability.

### Description
- Import the standalone windows and wire them into the app by adding `DataProcessingGUI` and `NASSetupGUI` imports in `seva/app/main.py` and replacing the previous `DataPlotter` construction with a direct call to `DataProcessingGUI(self.win)` in `_on_open_plotter`.
- Add `handle_open_nas_setup` in `seva/app/main.py` and pass it into `SettingsDialog` via a new `on_open_nas_setup` callback so the NAS setup UI is opened from Settings.
- Extend `seva/app/views/settings_dialog.py` to accept the `on_open_nas_setup` callback and add a compact `NAS` section with an `Open NAS Setup…` button that invokes the callback.
- Make `seva/app/nas_gui_smb.py` behave as an embeddable `tk.Toplevel` by changing `NASSetupGUI` to accept an optional `master`, create its own root when run standalone, and add `_on_close` cleanup so closing works when launched from the main app.

### Testing
- No automated tests were run for these UI wiring changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697823c87e608331b25f69c5e2571b27)