### PR TITLE
Fix NAS setup dialog focus

### DIFF
--- a/seva/app/nas_gui_smb.py
+++ b/seva/app/nas_gui_smb.py
@@ -63,6 +63,11 @@ class NASSetupGUI(tk.Toplevel):
         self.title("NAS Setup (SMB/CIFS)")
         self.geometry("560x520")
         self.protocol("WM_DELETE_WINDOW", self._on_close)
+        if master is not None:
+            self.transient(master)
+        self.lift()
+        self.focus_force()
+        self.grab_set()
 
         # API connection
         frm_api = ttk.LabelFrame(self, text="API Connection")


### PR DESCRIPTION
### Motivation
- The NAS setup dialog opened from the Settings window stayed behind other windows and did not reliably receive focus or user input, so make it behave like a focused/top dialog.

### Description
- In `seva/app/nas_gui_smb.py` inside `NASSetupGUI.__init__` call `self.transient(master)` when a `master` is provided and call `self.lift()`, `self.focus_force()`, and `self.grab_set()` so the dialog is raised, focused, and captures input.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979604d883883318107cf4d73ea21f3)