### PR TITLE
Add docs branch note and MkDocs metadata; update docs and nav

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Deploy MkDocs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+Thanks for contributing to SEVA. This guide summarizes how to work on the
+repository and keep changes aligned with the MVVM + Hexagonal architecture.
+
+## Workflow
+
+1. Create a feature branch from `main`.
+2. Keep PRs small and focused.
+3. Update docs when behavior changes.
+
+## Architecture guardrails
+
+- **Views**: UI/rendering only. No I/O, no domain rules, no mapping.
+- **ViewModels**: UI state + commands only. No network/filesystem I/O.
+- **UseCases**: Orchestrate workflows and call ports.
+- **Adapters**: Implement ports for I/O (HTTP, filesystem, discovery).
+- **Domain types**: Use domain objects above adapters (no raw dict/JSON).
+
+## Development
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the GUI:
+
+```bash
+python -m seva.app.main
+```
+
+Run the REST API (Linux/Raspberry Pi):
+
+```bash
+cd rest_api
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+## Tests
+
+From the repo root:
+
+```bash
+pytest -q
+```
+
+## Docs
+
+- Update `docs/` when behavior or workflow changes.
+- Run `mkdocs build` before shipping doc-heavy changes.

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -10,6 +10,16 @@ The SEVA GUI (`seva/`) follows MVVM + Hexagonal architecture and talks to the Fa
 - Adapters handle external I/O (HTTP, filesystem, discovery).
 - Domain modules own shared types, validation, naming, and normalization.
 
+```mermaid
+flowchart LR
+    subgraph GUI
+        View[View<br/>UI only] --> ViewModel[ViewModel<br/>State + commands]
+        ViewModel --> UseCase[UseCase<br/>Workflow orchestration]
+    end
+    UseCase --> Adapter[Adapter<br/>I/O boundary]
+    Adapter --> API[REST API / External Systems]
+```
+
 ## Cross-System Call-Chain
 
 A typical user action flows as:
@@ -19,3 +29,23 @@ A typical user action flows as:
 3. UseCase orchestration in `seva/usecases/*`.
 4. Adapter port call in `seva/adapters/*`.
 5. REST endpoint in `rest_api/app.py` and helper modules.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant View as View (Tkinter)
+    participant VM as ViewModel
+    participant UC as UseCase
+    participant Adapter as Adapter
+    participant API as REST API
+
+    User->>View: clicks / edits
+    View->>VM: command callback
+    VM->>UC: invoke use case
+    UC->>Adapter: port call
+    Adapter->>API: HTTP request
+    API-->>Adapter: response
+    Adapter-->>UC: domain data
+    UC-->>VM: updated state
+    VM-->>View: render updates
+```

--- a/docs/codex_guide.md
+++ b/docs/codex_guide.md
@@ -1,0 +1,81 @@
+# ChatGPT Codex Guide
+
+This guide shows how to use ChatGPT Codex effectively on this repository. It is
+aimed at Python developers who are new to the codebase and want reliable,
+architecture-safe changes.
+
+## Architecture guardrails to mention in prompts
+
+- **Views**: UI/rendering only. No I/O, no domain rules, no mapping.
+- **ViewModels**: UI state + commands only. No network/filesystem I/O.
+- **UseCases**: Orchestrate workflows, call ports.
+- **Adapters**: Implement ports for I/O (HTTP, filesystem, discovery).
+- **Domain types**: Use domain objects instead of raw dict/JSON above adapters.
+
+These rules help Codex avoid putting logic in the wrong layer.
+
+## Prompting checklist
+
+Before asking for code changes, include:
+
+1. **Goal** (what you want to change).
+2. **Scope** (which folders/files are relevant).
+3. **Architecture rules** (MVVM + Hexagonal boundaries above).
+4. **Constraints**:
+   - Avoid defensive programming for unlikely scenarios.
+   - Avoid KISS/YAGNI/DRY slogans as substitutes for reasoning.
+   - Provide a plan before coding.
+   - Prefer minimal, explicit changes with clear call chains.
+
+## Suggested prompt template
+
+```
+Goal:
+  Add/modify <feature> in the SEVA GUI.
+
+Scope:
+  - Relevant areas: seva/app/*, seva/viewmodels/*, seva/usecases/*, seva/adapters/*
+  - Ignore UI end-user docs.
+
+Architecture rules:
+  - Views are UI-only, no I/O.
+  - ViewModels are state/commands only, no network/filesystem I/O.
+  - UseCases orchestrate workflows and call ports.
+  - Adapters implement ports for I/O.
+  - Use domain objects above adapters.
+
+Constraints:
+  - Avoid defensive coding for unlikely paths.
+  - No KISS/YAGNI/DRY slogans; explain tradeoffs instead.
+  - Produce a plan first, then implement.
+
+Context:
+  - Link: docs/architecture_overview.md
+  - Link: docs/workflows_seva.md
+  - Link: docs/classes_seva.md
+```
+
+## Example prompt
+
+```
+Goal:
+  Add a new "Export Summary" action that saves a CSV from the run overview.
+
+Scope:
+  - GUI: seva/app/views/run_overview_view.py
+  - ViewModel: seva/viewmodels/runs_vm.py
+  - UseCase: seva/usecases/export_summary.py
+  - Adapter: seva/adapters/storage_local.py
+
+Architecture rules:
+  - Views are UI-only, no I/O.
+  - ViewModels are state/commands only, no network/filesystem I/O.
+  - UseCases orchestrate workflows and call ports.
+  - Adapters implement ports for I/O.
+  - Use domain objects above adapters.
+
+Constraints:
+  - Avoid defensive coding for unlikely paths.
+  - No KISS/YAGNI/DRY slogans; explain tradeoffs instead.
+  - Produce a plan first, then implement.
+```

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,72 @@
+# Development Setup
+
+This guide focuses on developers who are familiar with Python but new to the SEVA
+codebase. It covers setting up the GUI (Windows/Linux) and running the REST API
+on Linux/Raspberry Pi.
+
+## Prerequisites
+
+- Python 3.10–3.12
+- Git
+
+## Install dependencies
+
+From the repository root:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Run the GUI (Windows/Linux)
+
+Start the Tkinter GUI locally with:
+
+```bash
+python -m seva.app.main
+```
+
+If you need a custom storage root (where the GUI reads/writes local files), set
+`SEVA_STORAGE_ROOT` before starting:
+
+```bash
+SEVA_STORAGE_ROOT="path/to/storage" python -m seva.app.main
+```
+
+On Windows (PowerShell):
+
+```powershell
+$env:SEVA_STORAGE_ROOT="path\\to\\storage"
+python -m seva.app.main
+```
+
+## Run the REST API (Linux/Raspberry Pi)
+
+The REST API is intended to run on Linux/Raspberry Pi devices. On the Pi (or
+Linux host), start the FastAPI app from the directory where `rest_api/app.py`
+lives:
+
+```bash
+cd rest_api
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+### REST API environment variables
+
+You can customize the API with these environment variables:
+
+- `RUNS_ROOT`: Root directory where run data is stored. Defaults to `/opt/box/runs`.
+- `BOX_API_KEY`: Optional API key for securing requests.
+- `BOX_ID`: Identifier for the box (used in health/device responses).
+- `BOX_BUILD` / `BOX_BUILD_ID`: Optional build metadata for versioning.
+
+Example:
+
+```bash
+RUNS_ROOT="/opt/box/runs" BOX_ID="A" uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+## Next steps
+
+- Review the **Architecture Overview** for MVVM + Hexagonal boundaries.
+- Use **SEVA GUI workflows** and **REST API workflows** to navigate use cases.
+- Check **Troubleshooting** for common issues.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,106 @@
+# Glossary
+
+This glossary mixes domain terms (runs, wells, boxes) with MVVM + Hexagonal
+architecture terms so new developers can reason about the system without prior
+framework knowledge. Each entry includes a short definition and a pointer to
+where the concept lives in code.
+
+## MVVM + Hexagonal terms
+
+**View**  
+UI widgets and rendering logic only. Views expose callbacks and never perform
+I/O or business logic. See `seva/app/views/*`.
+
+**ViewModel**  
+State + commands used by views. ViewModels coordinate UI state but do not touch
+adapters or build API payloads. See `seva/viewmodels/*`.
+
+**UseCase**  
+Workflow orchestration that coordinates domain rules and adapters (e.g., save
+layout, start jobs, cancel runs). See `seva/usecases/*`.
+
+**Adapter**  
+I/O boundary implementation for a port (HTTP, filesystem, relay, discovery).
+Adapters are called by use cases or controllers but never orchestrate flows.
+See `seva/adapters/*`.
+
+**Port**  
+A protocol that defines the boundary between use cases and external systems.
+Adapters implement ports, and use cases depend on ports. See
+`seva/domain/ports.py`.
+
+**Domain type**  
+Value objects that normalize and validate identifiers and snapshots early.
+See `seva/domain/entities.py` for `RunId`, `GroupId`, `WellId`, and more.
+
+## Domain terms
+
+**Box**  
+A hardware enclosure (Pi + potentiostat) addressed by a `BoxId`. See
+`seva/domain/entities.py`.
+
+**Run**  
+An individual experiment execution on the backend, identified by a `RunId`. See
+`seva/domain/entities.py`.
+
+**Group**  
+A collection of related runs started together, identified by a `GroupId` (or
+`RunGroupId` in ports). See `seva/domain/entities.py` and `seva/domain/ports.py`.
+
+**Well**  
+A plate position within a batch plan. Represented by `WellId`. See
+`seva/domain/entities.py`.
+
+**Mode**  
+The electrochemistry mode applied to a well (e.g., CV, EIS). Mode tokens are
+normalized via domain utilities (see `seva/domain/modes.py`).
+
+**Layout**  
+Saved plate configuration (selection + parameters) persisted locally by the
+storage adapter. See `seva/adapters/storage_local.py` and
+`seva/usecases/save_plate_layout.py`.
+
+## Code examples (MVVM + Hexagonal call chain)
+
+### View → ViewModel callbacks
+
+Views receive callbacks that delegate to ViewModel commands (no I/O in views).
+
+```python
+self.wellgrid = WellGridView(
+    self.win.wellgrid_host,
+    boxes=initial_boxes,
+    on_select_wells=lambda sel: self.plate_vm.set_selection(sel),
+    on_copy_params_from=lambda wid: self.plate_vm.cmd_copy_from(wid),
+    on_paste_params_to_selection=self.plate_vm.cmd_paste_to_selection,
+)
+```
+
+Source: `seva/app/main.py`
+
+### UseCase → Port (adapter boundary)
+
+Use cases call ports to persist or fetch data. Ports are implemented by
+adapters.
+
+```python
+return self.storage.save_layout(name, payload)
+```
+
+Source: `seva/usecases/save_plate_layout.py`
+
+### Adapter implements a Port
+
+Adapters implement port methods to perform I/O. This adapter writes JSON layouts
+to disk.
+
+```python
+def save_layout(self, name: str, payload: Dict) -> Path:
+    path = self._layout_path(name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return path
+```
+
+Source: `seva/adapters/storage_local.py`

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,13 +5,42 @@ Welcome to the SEVA documentation.
 This documentation is intended for developers working on the SEVA GUI
 (MVVM architecture) and the associated REST API.
 
+> Docs track the `main` branch unless otherwise noted.
+
 ## Start here
 
 If you are new to the project, follow this order:
 
-1. Read the **Architecture Overview**
-2. Explore the **SEVA GUI workflows**
-3. Dive into class and module documentation as needed
+1. Read **What is this repo?** (below) to understand the scope.
+2. Set up your environment in **[Development Setup](dev-setup.md)**.
+3. Review the **[Architecture Overview](architecture_overview.md)** to learn the MVVM + Hexagonal boundaries.
+4. Explore the **[SEVA GUI workflows](workflows_seva.md)** and **[REST API workflows](workflows_rest_api.md)**.
+5. Use **[Troubleshooting](troubleshooting.md)** and the **[Glossary](glossary.md)** when you get stuck.
+6. Review the **[ChatGPT Codex Guide](codex_guide.md)** for AI-assisted changes.
+
+### What is this repo?
+
+This repository contains the SEVA GUI (MVVM + Hexagonal architecture) and the
+associated REST API service. The GUI lives in `seva/`, and the REST API lives
+in `rest_api/`.
+
+### How to run GUI locally (Windows/Linux)
+
+Follow the steps in **[Development Setup](dev-setup.md)** to configure Python and start the GUI.
+
+### How to run REST API locally (Linux/Raspberry Pi)
+
+See **[Development Setup](dev-setup.md)** for Linux/Raspberry Pi-specific instructions
+for the FastAPI service.
+
+### Where to change what? (View vs ViewModel vs UseCase)
+
+Use this quick guide when deciding where a change should live:
+
+- **Views** (`seva/app/views/*`): UI rendering only.
+- **ViewModels** (`seva/viewmodels/*`): UI state + commands.
+- **UseCases** (`seva/usecases/*`): Orchestration and workflows.
+- **Adapters** (`seva/adapters/*`): External I/O (HTTP, filesystem, discovery).
 
 ## Scope
 
@@ -22,3 +51,15 @@ This documentation focuses on:
 - responsibilities of major modules
 
 It does **not** document UI usage for end users.
+
+## Documentation map
+
+Follow this order for a linear tour through the docs:
+
+1. **[Development Setup](dev-setup.md)** (local environment + run GUI/API)
+2. **[Architecture Overview](architecture_overview.md)** (MVVM + Hexagonal boundaries)
+3. **[SEVA GUI workflows](workflows_seva.md)**
+4. **[REST API workflows](workflows_rest_api.md)**
+5. **[Troubleshooting](troubleshooting.md)**
+6. **[Glossary](glossary.md)**
+7. **[ChatGPT Codex Guide](codex_guide.md)**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,55 @@
+# Troubleshooting
+
+This page lists common issues when working with the GUI and the REST API, along
+with quick fixes and where to look for logs.
+
+## Nothing discovered
+
+If device discovery returns nothing:
+
+1. Verify the REST API is running on the target device.
+2. In the GUI **Settings**, confirm the base URL/IP and port are correct.
+3. Use **Test Connection** to verify `/health` and `/devices` respond.
+4. On the Pi, ensure devices are attached and recognized by the OS.
+
+## Wrong base URL / API not reachable
+
+Symptoms: errors on startup, failed polls, or "connection refused".
+
+- Check the GUI **Settings** → API base URL/IP for each box.
+- Confirm the API is reachable from the GUI host:
+
+```bash
+curl http://<box-ip>:8000/health
+```
+
+## Downloads do not open the folder
+
+Depending on OS policies, the "open folder" action might be blocked.
+
+- **Windows**: ensure the Results directory exists and is writable.
+- **Linux**: confirm that the default file manager is available for your desktop
+  environment.
+- If the folder does not open, manually navigate to the Results directory and
+  verify files were downloaded.
+
+## Logging & debug output
+
+### GUI debug logging
+
+Enable **Settings → Enable debug logging** to increase verbosity for the GUI.
+
+You can also force logging levels via environment variables:
+
+- `SEVA_LOG_LEVEL` / `SEVA_GUI_LOG_LEVEL` (explicit level like `DEBUG`)
+- `SEVA_DEBUG_LOGGING` / `SEVA_GUI_DEBUG` / `SEVA_DEBUG` (truthy → DEBUG)
+
+### REST API logging
+
+Use `uvicorn` with the default logging output or increase verbosity via:
+
+```bash
+uvicorn app:app --host 0.0.0.0 --port 8000 --log-level debug
+```
+
+If you need more detail, check the system logs on the Pi host.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: SEVA GUI – Architecture & Developer Documentation
 site_description: Developer documentation for the SEVA GUI (MVVM) and REST API
 site_author: LunatiChemist
+copyright: Docs track the main branch.
 
 repo_name: LunatiChemist/SEVA_GUI_MVVM
 repo_url: https://github.com/LunatiChemist/SEVA_GUI_MVVM
@@ -21,6 +22,9 @@ theme:
 plugins:
   - search
 
+extra:
+  docs_branch: main
+
 markdown_extensions:
   - admonition
   - toc:
@@ -30,14 +34,12 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-
-  - Overview:
-      - Architecture Overview: architecture_overview.md
-
-  - SEVA GUI:
-      - Classes & Modules: classes_seva.md
-      - Workflows: workflows_seva.md
-
-  - REST API:
-      - Classes & Modules: classes_rest_api.md
-      - Workflows: workflows_rest_api.md
+  - Development Setup: dev-setup.md
+  - Architecture Overview: architecture_overview.md
+  - SEVA GUI Workflows: workflows_seva.md
+  - SEVA GUI Classes & Modules: classes_seva.md
+  - REST API Workflows: workflows_rest_api.md
+  - REST API Classes & Modules: classes_rest_api.md
+  - Troubleshooting: troubleshooting.md
+  - Glossary: glossary.md
+  - ChatGPT Codex Guide: codex_guide.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ python-multipart
 #git+https://github.com/aurelienblanc2/Potentiostat-driver-pyBEEP.git#egg=pyBEEP
 -e ./vendor/pyBEEP
 
+# Documentation
+mkdocs
 
 # Tests
 pytest


### PR DESCRIPTION
### Motivation

- Make branch context explicit in the documentation so readers know docs track `main` unless noted.  
- Surface developer onboarding content and architecture guardrails in the site navigation to improve discoverability.  
- Provide CI automation and metadata so documentation builds and branch context can be validated and published consistently.

### Description

- Add a branch note to `docs/index.md` clarifying that the documentation tracks the `main` branch and expand the start/what-is-this sections.  
- Update `mkdocs.yml` to include a `copyright` line, an `extra.docs_branch: main` metadata entry, and a reorganized `nav` to surface setup, architecture, workflows, glossary, and the Codex guide.  
- Add new documentation pages including `docs/dev-setup.md`, `docs/glossary.md`, `docs/troubleshooting.md`, `docs/codex_guide.md`, and enrich `docs/architecture_overview.md` with diagrams.  
- Add `CONTRIBUTING.md` and a GitHub Actions workflow `.github/workflows/docs.yml` that installs dependencies and runs `mkdocs build --strict` and `mkdocs gh-deploy --force` on pushes to `main`.

### Testing

- No local automated tests were run for these documentation-only changes.  
- A CI job was added at `.github/workflows/docs.yml` that will validate the docs by running `pip install -r requirements.txt` and `mkdocs build --strict` in GitHub Actions on pushes to `main`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983c9f8b7c88331b0c82665cc460c45)