### PR TITLE
chore: normalize imports, update pyproject/requirements, README and GH templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: 🐛 Bug report
+about: Report a reproducible bug or regression
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
+---
+
+## Summary
+Describe the bug in 1–2 sentences.
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Expected Behavior
+What did you expect to happen?
+
+## Actual Behavior
+What actually happened?
+
+## Environment
+- OS:
+- Python version:
+- App version/commit:
+
+## Logs/Screenshots
+Attach logs or screenshots if available.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: ✨ Feature request
+about: Suggest an idea or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees: []
+---
+
+## Summary
+Describe the feature or improvement.
+
+## Problem Statement
+What problem does this solve? Who benefits?
+
+## Proposed Solution
+How should it work? Include UI/UX notes if relevant.
+
+## Alternatives Considered
+What other approaches did you consider?
+
+## Additional Context
+Links, mockups, or related issues.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+- 
+
+## Testing
+- [ ] Not run (explain why)
+- [ ] Tests run (list commands and results)
+
+## Checklist
+- [ ] Docs updated (if needed)
+- [ ] Requirements/pyproject updated (if needed)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It follows a clean **MVVM + Hexagonal** architecture: Views are UI‑only; ViewM
   - Poll aggregates **run/box progress** and **remaining time** and updates the Run Overview table. 
   - Download retrieves results per **group** and mirrors the Pi folder structure locally (ZIPs are unpacked).
 - **Cancel Group** and **End Selection**:
-  - Cancel a whole group or only the **currently selected runs** (by `run_id`). :contentReference[oaicite:7]{index=7}
+  - Cancel a whole group or only the **currently selected runs** (by `run_id`).
 
 ### Panels & buttons (what they do)
 - **Well Grid**: select one or many wells; configured wells are highlighted; clipboard‑style **Copy/Paste** per mode applies the current form values (incl. flags) from the Experiment panel to multiple wells at once.
@@ -37,7 +37,7 @@ It follows a clean **MVVM + Hexagonal** architecture: Views are UI‑only; ViewM
 2. **Poll**  
    The GUI calls group status, merges per‑run snapshots and computes **progress/remaining** using start time and planned duration; box headers show average progress.
 3. **Download**  
-   The GUI downloads **ZIPs** per group, **extracts** them, and mirrors the server’s structure into your **Results** directory. (Optionally, slot folders can be mapped to WellIDs). :contentReference[oaicite:19]{index=19}
+   The GUI downloads **ZIPs** per group, **extracts** them, and mirrors the server’s structure into your **Results** directory. (Optionally, slot folders can be mapped to WellIDs).
 
 ---
 
@@ -61,13 +61,18 @@ It follows a clean **MVVM + Hexagonal** architecture: Views are UI‑only; ViewM
 2. Run the GUI:  
    ```bash
    python -m seva.app.main
+   ```
 3. In Settings, set the Pi box IP (default port 8000) and a Results directory; save.
 
 ## Pi Box API (on Raspberry Pi)
 
+```bash
 cd /opt/box
 uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
 ENV (optional): BOX_API_KEY="", BOX_ID="", RUNS_ROOT="/opt/box/runs"
+
 The API exposes health, devices, modes, validation, jobs, and file download endpoints
 
 ### Configuration (short)
@@ -88,12 +93,14 @@ The API exposes health, devices, modes, validation, jobs, and file download endp
 | `GET /jobs/status`                        | Bulk snapshot for multiple runs.                                       |      |                              |
 | `GET /jobs/{run_id}`                      | Single run status; includes computed `progress_pct` and `remaining_s`. |      |                              |
 | `POST /jobs/{run_id}/cancel`              | Cancel a run.                                                          |      |                              |
-| `GET /runs/{run_id}/files                 | file                                                                   | zip` | List/serve/zip result files. |
+| `GET /runs/{run_id}/files`                | List result files.                                                     |      |                              |
+| `GET /runs/{run_id}/file`                 | Download a single result file.                                         |      |                              |
+| `GET /runs/{run_id}/zip`                  | Download all result files as a ZIP archive.                            |      |                              |
 | `POST /admin/rescan`                      | Refresh device registry.                                               |      |                              |
 |                                           |                                                                        |      |                              |
 
 ### Naming & paths (short)
-The GUI creates a group id from (Experiment[__Subdir]__ClientDatetime__rnd4) and passes it to the server. The Pi stores runs under a sanitized folder hierarchy; the GUI mirrors this when 
+The GUI creates a group id from (Experiment[__Subdir]__ClientDatetime__rnd4) and passes it to the server. The Pi stores runs under a sanitized folder hierarchy; the GUI mirrors this when downloading results.
 
 ---
 
@@ -103,7 +110,7 @@ The GUI creates a group id from (Experiment[__Subdir]__ClientDatetime__rnd4) and
   - `seva/` — GUI app (Views/UI only; ViewModels; UseCases; Adapters).  
   - `rest_api/` — FastAPI app for the Pi (deploys to `/opt/box/app.py` on the device).  
 - **Coding standards**  
-  - MVVM + Hexagon; English comments; docstrings; small PRs with tests; no client‑side fallbacks if server validates. :contentReference[oaicite:42]{index=42}
+  - MVVM + Hexagon; English comments; docstrings; small PRs with tests; no client‑side fallbacks if server validates.
 - **Testing**  
   - `pytest -q` from the repo root; mock adapters for UseCases (start/poll/cancel/download).  
 - **Linting**  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,3 @@
-
----
-
-## `pyproject.toml`
-
-```toml
-
 [build-system]
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
@@ -18,6 +11,21 @@ license = { text = "MIT" }
 authors = [{ name = "SEVA Team" }]
 requires-python = ">=3.10,<3.13"
 keywords = ["electrochemistry", "mvvm", "fastapi", "tkinter", "pyBEEP"]
+dependencies = [
+  "requests",
+  "matplotlib",
+  "Pillow",
+  "numpy",
+  "fastapi",
+  "uvicorn[standard]",
+  "pydantic",
+  "pyserial",
+  "python-multipart",
+  "mkdocs",
+]
+
+[project.optional-dependencies]
+dev = ["pytest"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,22 @@
 # GUI / Client
-requests
-matplotlib
-Pillow
-numpy
+requests>=2.31
+matplotlib>=3.7
+Pillow>=10.0
+numpy>=1.24
 
 # Server / API
-fastapi
-uvicorn[standard]
-pydantic
-pyserial
-python-multipart
+fastapi>=0.100
+uvicorn[standard]>=0.23
+pydantic>=1.10,<3
+pyserial>=3.5
+python-multipart>=0.0.6
 
 # Potentiostat driver (pyBEEP)
 #git+https://github.com/aurelienblanc2/Potentiostat-driver-pyBEEP.git#egg=pyBEEP
 -e ./vendor/pyBEEP
 
 # Documentation
-mkdocs
+mkdocs>=1.5
 
 # Tests
-pytest
+pytest>=7.4

--- a/seva/adapters/device_rest.py
+++ b/seva/adapters/device_rest.py
@@ -21,7 +21,7 @@ import requests
 from seva.domain.mapping import extract_device_entries
 from seva.domain.ports import BoxId, DevicePort
 
-from .api_errors import (
+from seva.adapters.api_errors import (
     ApiClientError,
     ApiError,
     ApiServerError,
@@ -30,7 +30,7 @@ from .api_errors import (
     extract_error_hint,
     parse_error_payload,
 )
-from .http_client import HttpConfig, RetryingSession
+from seva.adapters.http_client import HttpConfig, RetryingSession
 
 
 class DeviceRestAdapter(DevicePort):

--- a/seva/adapters/firmware_rest.py
+++ b/seva/adapters/firmware_rest.py
@@ -20,7 +20,7 @@ import requests
 
 from seva.domain.ports import BoxId, FirmwarePort
 
-from .api_errors import (
+from seva.adapters.api_errors import (
     ApiClientError,
     ApiError,
     ApiServerError,
@@ -29,7 +29,7 @@ from .api_errors import (
     extract_error_hint,
     parse_error_payload,
 )
-from .http_client import HttpConfig, RetryingSession
+from seva.adapters.http_client import HttpConfig, RetryingSession
 
 
 class FirmwareRestAdapter(FirmwarePort):

--- a/seva/adapters/http_client.py
+++ b/seva/adapters/http_client.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, Optional
 import requests
 from requests import exceptions as req_exc
 
-from .api_errors import ApiTimeoutError
+from seva.adapters.api_errors import ApiTimeoutError
 
 
 @dataclass

--- a/seva/adapters/job_rest.py
+++ b/seva/adapters/job_rest.py
@@ -37,8 +37,8 @@ from seva.domain.mapping import (
 )
 from seva.domain.ports import JobPort, RunGroupId, BoxId
 
-from .http_client import HttpConfig, RetryingSession
-from .api_errors import (
+from seva.adapters.http_client import HttpConfig, RetryingSession
+from seva.adapters.api_errors import (
     ApiClientError,
     ApiError,
     ApiServerError,

--- a/seva/app/controller.py
+++ b/seva/app/controller.py
@@ -9,20 +9,20 @@ from __future__ import annotations
 
 from typing import Optional
 
-from ..adapters.device_rest import DeviceRestAdapter
-from ..adapters.firmware_rest import FirmwareRestAdapter
-from ..adapters.job_rest import JobRestAdapter
-from ..usecases.cancel_group import CancelGroup
-from ..usecases.download_group_results import DownloadGroupResults
-from ..usecases.flash_firmware import FlashFirmware
-from ..usecases.poll_device_status import PollDeviceStatus
-from ..usecases.poll_group_status import PollGroupStatus
-from ..usecases.start_experiment_batch import StartExperimentBatch
-from ..usecases.test_connection import TestConnection
-from ..viewmodels.settings_vm import SettingsVM
+from seva.adapters.device_rest import DeviceRestAdapter
+from seva.adapters.firmware_rest import FirmwareRestAdapter
+from seva.adapters.job_rest import JobRestAdapter
+from seva.usecases.cancel_group import CancelGroup
+from seva.usecases.download_group_results import DownloadGroupResults
+from seva.usecases.flash_firmware import FlashFirmware
+from seva.usecases.poll_device_status import PollDeviceStatus
+from seva.usecases.poll_group_status import PollGroupStatus
+from seva.usecases.start_experiment_batch import StartExperimentBatch
+from seva.usecases.test_connection import TestConnection
+from seva.viewmodels.settings_vm import SettingsVM
 
 try:
-    from ..usecases.cancel_runs import CancelRuns as _CancelRunsClass
+    from seva.usecases.cancel_runs import CancelRuns as _CancelRunsClass
 except ImportError:
     _CancelRunsClass = None
 

--- a/seva/app/discovery_controller.py
+++ b/seva/app/discovery_controller.py
@@ -17,10 +17,10 @@ from seva.usecases.discover_and_assign_devices import (
 )
 from seva.viewmodels.settings_vm import SettingsVM
 from seva.domain.ports import StoragePort
-from .views.discovery_results_dialog import DiscoveryResultsDialog
+from seva.app.views.discovery_results_dialog import DiscoveryResultsDialog
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .views.settings_dialog import SettingsDialog
+    from seva.app.views.settings_dialog import SettingsDialog
 
 
 class DiscoveryController:

--- a/seva/app/main.py
+++ b/seva/app/main.py
@@ -39,46 +39,46 @@ from tkinter import filedialog
 from typing import Dict, Set, Optional, List, TYPE_CHECKING
 
 # ---- Views (UI-only) ----
-from .views.main_window import MainWindowView
-from .views.well_grid_view import WellGridView
-from .views.experiment_panel_view import ExperimentPanelView
-from .views.run_overview_view import RunOverviewView
-from .views.channel_activity_view import ChannelActivityView
-from .views.settings_dialog import SettingsDialog
-from .dataplotter_standalone import DataProcessingGUI
-from .discovery_controller import DiscoveryController
-from .settings_controller import SettingsController
-from .download_controller import DownloadController
-from .views.runs_panel_view import RunsPanelView
+from seva.app.dataplotter_standalone import DataProcessingGUI
+from seva.app.discovery_controller import DiscoveryController
+from seva.app.download_controller import DownloadController
+from seva.app.settings_controller import SettingsController
+from seva.app.views.channel_activity_view import ChannelActivityView
+from seva.app.views.experiment_panel_view import ExperimentPanelView
+from seva.app.views.main_window import MainWindowView
+from seva.app.views.run_overview_view import RunOverviewView
+from seva.app.views.runs_panel_view import RunsPanelView
+from seva.app.views.settings_dialog import SettingsDialog
+from seva.app.views.well_grid_view import WellGridView
 
 # ---- ViewModels ----
-from ..viewmodels.plate_vm import PlateVM
-from ..viewmodels.experiment_vm import ExperimentVM
-from ..viewmodels.progress_vm import ProgressVM
-from ..viewmodels.settings_vm import SettingsVM, BOX_IDS
-from ..viewmodels.live_data_vm import LiveDataVM
-from ..viewmodels.runs_vm import RunsVM
+from seva.viewmodels.experiment_vm import ExperimentVM
+from seva.viewmodels.live_data_vm import LiveDataVM
+from seva.viewmodels.plate_vm import PlateVM
+from seva.viewmodels.progress_vm import ProgressVM
+from seva.viewmodels.runs_vm import RunsVM
+from seva.viewmodels.settings_vm import BOX_IDS, SettingsVM
 
 # ---- UseCases & Adapter ----
-from .run_flow_presenter import RunFlowPresenter
-from ..adapters.storage_local import StorageLocal
-from ..adapters.discovery_http import HttpDiscoveryAdapter
-from ..adapters.relay_mock import RelayMock
-from ..usecases.save_plate_layout import SavePlateLayout
-from ..usecases.load_plate_layout import LoadPlateLayout
-from ..usecases.build_experiment_plan import BuildExperimentPlan
-from ..usecases.build_storage_meta import BuildStorageMeta
-from ..domain.runs_registry import RunsRegistry
-from ..domain.ports import UseCaseError
-from ..usecases.test_relay import TestRelay
-from ..usecases.set_electrode_mode import SetElectrodeMode
-from ..usecases.discover_devices import DiscoverDevices, MergeDiscoveredIntoRegistry
-from ..usecases.discover_and_assign_devices import DiscoverAndAssignDevices
-from ..utils import logging as logging_utils
-from .controller import AppController
+from seva.adapters.discovery_http import HttpDiscoveryAdapter
+from seva.adapters.relay_mock import RelayMock
+from seva.adapters.storage_local import StorageLocal
+from seva.app.controller import AppController
+from seva.app.run_flow_presenter import RunFlowPresenter
+from seva.domain.ports import UseCaseError
+from seva.domain.runs_registry import RunsRegistry
+from seva.usecases.build_experiment_plan import BuildExperimentPlan
+from seva.usecases.build_storage_meta import BuildStorageMeta
+from seva.usecases.discover_and_assign_devices import DiscoverAndAssignDevices
+from seva.usecases.discover_devices import DiscoverDevices, MergeDiscoveredIntoRegistry
+from seva.usecases.load_plate_layout import LoadPlateLayout
+from seva.usecases.save_plate_layout import SavePlateLayout
+from seva.usecases.set_electrode_mode import SetElectrodeMode
+from seva.usecases.test_relay import TestRelay
+from seva.utils import logging as logging_utils
 
 if TYPE_CHECKING:
-    from ..usecases.cancel_runs import CancelRuns
+    from seva.usecases.cancel_runs import CancelRuns
 
 logging_utils.configure_root()
 

--- a/seva/app/run_flow_presenter.py
+++ b/seva/app/run_flow_presenter.py
@@ -44,8 +44,8 @@ from seva.viewmodels.runs_vm import RunsVM
 from seva.viewmodels.settings_vm import SettingsVM
 from seva.app.polling_scheduler import PollingScheduler
 
-from .controller import AppController
-from ..adapters.storage_local import StorageLocal
+from seva.adapters.storage_local import StorageLocal
+from seva.app.controller import AppController
 
 
 @dataclass

--- a/seva/domain/__init__.py
+++ b/seva/domain/__init__.py
@@ -1,7 +1,7 @@
 
 """Domain package exports for value objects and aggregates."""
 
-from .entities import (
+from seva.domain.entities import (
     BoxId,
     BoxSnapshot,
     ClientDateTime,
@@ -19,9 +19,9 @@ from .entities import (
     WellId,
     WellPlan,
 )
-from .naming import make_group_id
-from .plan_builder import build_meta
-from .snapshot_normalizer import normalize_status
+from seva.domain.naming import make_group_id
+from seva.domain.plan_builder import build_meta
+from seva.domain.snapshot_normalizer import normalize_status
 
 __all__ = [
     "BoxId",

--- a/seva/domain/modes.py
+++ b/seva/domain/modes.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Iterable, Mapping, Optional, Tuple
 
-from .params import ACParams, CVParams, ModeParams
-from .util import normalize_mode_name
+from seva.domain.params import ACParams, CVParams, ModeParams
+from seva.domain.util import normalize_mode_name
 
 
 @dataclass(frozen=True)

--- a/seva/domain/naming.py
+++ b/seva/domain/naming.py
@@ -7,7 +7,7 @@ import random
 import re
 import string
 
-from .entities import ClientDateTime, GroupId, PlanMeta
+from seva.domain.entities import ClientDateTime, GroupId, PlanMeta
 
 _SANITIZE_PATTERN = re.compile(r"[^A-Za-z0-9_-]+")
 _RANDOM_ALPHABET = string.ascii_uppercase + string.digits

--- a/seva/domain/params/__init__.py
+++ b/seva/domain/params/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from ..entities import ModeParams
-from .ac import ACParams  # noqa: E402
-from .cv import CVParams  # noqa: E402
+from seva.domain.entities import ModeParams
+from seva.domain.params.ac import ACParams  # noqa: E402
+from seva.domain.params.cv import CVParams  # noqa: E402
 
 __all__ = ["ModeParams", "CVParams", "ACParams"]

--- a/seva/domain/params/ac.py
+++ b/seva/domain/params/ac.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, MutableMapping, Optional
 
-from . import ModeParams
+from seva.domain.params import ModeParams
 
 _FLAG_KEYS = (
     "run_cv",

--- a/seva/domain/params/cv.py
+++ b/seva/domain/params/cv.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, MutableMapping
 
-from . import ModeParams
+from seva.domain.params import ModeParams
 
 _FLAG_KEYS = (
     "run_cv",

--- a/seva/domain/plan_builder.py
+++ b/seva/domain/plan_builder.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, Mapping, Optional
 
-from .entities import (
+from seva.domain.entities import (
     ClientDateTime,
     ExperimentPlan,
     ModeName,
@@ -15,8 +15,8 @@ from .entities import (
     WellPlan,
     GroupId,
 )
-from .naming import make_group_id_from_parts
-from .params import CVParams, ModeParams
+from seva.domain.naming import make_group_id_from_parts
+from seva.domain.params import CVParams, ModeParams
 
 _MODE_BUILDERS: Dict[str, type[ModeParams]] = {
     "CV": CVParams,

--- a/seva/domain/ports.py
+++ b/seva/domain/ports.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Protocol, Tuple
 
-from .entities import BoxId, ExperimentPlan, WellId
+from seva.domain.entities import BoxId, ExperimentPlan, WellId
 
 RunGroupId = str
 

--- a/seva/domain/snapshot_normalizer.py
+++ b/seva/domain/snapshot_normalizer.py
@@ -7,7 +7,7 @@ import math
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional, Sequence
 
-from .entities import (
+from seva.domain.entities import (
     BoxId,
     BoxSnapshot,
     GroupId,

--- a/seva/domain/storage_meta.py
+++ b/seva/domain/storage_meta.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Mapping, Optional
 
-from .time_utils import parse_client_datetime
+from seva.domain.time_utils import parse_client_datetime
 
 
 @dataclass(frozen=True)

--- a/seva/usecases/cancel_group.py
+++ b/seva/usecases/cancel_group.py
@@ -6,8 +6,8 @@ errors through shared error-mapping helpers.
 
 from __future__ import annotations
 from dataclasses import dataclass
-from ..domain.ports import JobPort, UseCaseError, RunGroupId
-from ..usecases.error_mapping import map_api_error
+from seva.domain.ports import JobPort, UseCaseError, RunGroupId
+from seva.usecases.error_mapping import map_api_error
 
 
 @dataclass

--- a/seva/usecases/cancel_runs.py
+++ b/seva/usecases/cancel_runs.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Set
 
-from ..domain.ports import JobPort
-from ..usecases.error_mapping import map_api_error
+from seva.domain.ports import JobPort
+from seva.usecases.error_mapping import map_api_error
 
 
 @dataclass

--- a/seva/usecases/download_group_results.py
+++ b/seva/usecases/download_group_results.py
@@ -13,10 +13,10 @@ import zipfile
 from dataclasses import dataclass
 from typing import Dict, Iterable, Mapping, Optional, Tuple
 
-from ..domain.mapping import normalize_slot_registry, resolve_well_id
-from ..domain.ports import JobPort, RunGroupId, UseCaseError
-from ..usecases.error_mapping import map_api_error
-from ..domain.storage_meta import StorageMeta
+from seva.domain.mapping import normalize_slot_registry, resolve_well_id
+from seva.domain.ports import JobPort, RunGroupId, UseCaseError
+from seva.usecases.error_mapping import map_api_error
+from seva.domain.storage_meta import StorageMeta
 
 
 CleanupMode = str

--- a/seva/usecases/load_plate_layout.py
+++ b/seva/usecases/load_plate_layout.py
@@ -9,11 +9,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, TYPE_CHECKING
 
-from ..domain.ports import StoragePort, UseCaseError
+from seva.domain.ports import StoragePort, UseCaseError
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ..viewmodels.experiment_vm import ExperimentVM
-    from ..viewmodels.plate_vm import PlateVM
+    from seva.viewmodels.experiment_vm import ExperimentVM
+    from seva.viewmodels.plate_vm import PlateVM
 
 
 @dataclass

--- a/seva/usecases/save_plate_layout.py
+++ b/seva/usecases/save_plate_layout.py
@@ -9,10 +9,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, TYPE_CHECKING
 
-from ..domain.ports import StoragePort, UseCaseError, WellId
+from seva.domain.ports import StoragePort, UseCaseError, WellId
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ..viewmodels.experiment_vm import ExperimentVM
+    from seva.viewmodels.experiment_vm import ExperimentVM
 
 
 @dataclass

--- a/seva/usecases/set_electrode_mode.py
+++ b/seva/usecases/set_electrode_mode.py
@@ -7,7 +7,7 @@ consistent UI error presentation.
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
-from ..domain.ports import RelayPort, UseCaseError
+from seva.domain.ports import RelayPort, UseCaseError
 
 
 @dataclass
@@ -45,4 +45,3 @@ class SetElectrodeMode:
             self.relay.set_electrode_mode(mode)
         except Exception as exc:  # pragma: no cover - defensive
             raise UseCaseError("RELAY_SET_MODE_FAILED", str(exc))
-

--- a/seva/usecases/test_relay.py
+++ b/seva/usecases/test_relay.py
@@ -6,7 +6,7 @@ error codes for UI display.
 
 from __future__ import annotations
 from dataclasses import dataclass
-from ..domain.ports import RelayPort, UseCaseError
+from seva.domain.ports import RelayPort, UseCaseError
 
 
 @dataclass

--- a/seva/viewmodels/experiment_vm.py
+++ b/seva/viewmodels/experiment_vm.py
@@ -19,8 +19,8 @@ Non-goals:
 from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Mapping, Optional, Set, Iterable
-from ..domain import WellId, ModeName
-from ..domain.modes import ModeRegistry
+from seva.domain import WellId, ModeName
+from seva.domain.modes import ModeRegistry
 
 @dataclass
 class ExperimentVM:

--- a/seva/viewmodels/plate_vm.py
+++ b/seva/viewmodels/plate_vm.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
 
-from ..domain.util import well_id_to_box
+from seva.domain.util import well_id_to_box
 
 WellId = str  # e.g., "A1"
 BoxId = str   # e.g., "A"

--- a/seva/viewmodels/progress_vm.py
+++ b/seva/viewmodels/progress_vm.py
@@ -15,12 +15,12 @@ import time
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
-from ..domain.entities import BoxId, BoxSnapshot, GroupSnapshot, RunStatus, WellId
-from ..domain.runs_registry import RunsRegistry
-from ..domain.snapshot_normalizer import normalize_status
-from ..domain.util import well_id_to_box
-from .status_format import phase_key, phase_label
-from ..domain.device_activity import DeviceActivitySnapshot
+from seva.domain.entities import BoxId, BoxSnapshot, GroupSnapshot, RunStatus, WellId
+from seva.domain.runs_registry import RunsRegistry
+from seva.domain.snapshot_normalizer import normalize_status
+from seva.domain.util import well_id_to_box
+from seva.viewmodels.status_format import phase_key, phase_label
+from seva.domain.device_activity import DeviceActivitySnapshot
 
 # -- top of file / next to the other type aliases:
 WellRow = Tuple[str, str, str, str, Optional[float], str, str, str]

--- a/seva/viewmodels/runs_vm.py
+++ b/seva/viewmodels/runs_vm.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from seva.domain.runs_registry import RunEntry, RunsRegistry
-from .status_format import registry_status_label
+from seva.viewmodels.status_format import registry_status_label
 
 
 @dataclass

--- a/seva/viewmodels/settings_vm.py
+++ b/seva/viewmodels/settings_vm.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field, replace
 from typing import Any, Callable, Dict, Mapping, Optional
 
-from ..utils.logging import env_requests_debug
+from seva.utils.logging import env_requests_debug
 
 BoxId = str
 BOX_IDS: tuple[BoxId, ...] = ("A", "B", "C", "D")


### PR DESCRIPTION
### Motivation
- Normalize module imports to absolute `seva.*` paths to avoid fragile relative imports and improve package visibility across the codebase.
- Refresh repository metadata and dependency declarations to be explicit and reproducible for packaging and CI.
- Fix README quick-start / API table formatting for accuracy and clarity.
- Add GitHub issue and PR templates to improve contributor experience.

### Description
- Replaced many relative imports with absolute imports (e.g. `from seva.domain...`, `from seva.app...`, `from seva.adapters...`) across app, domain, adapters, usecases, and viewmodels (multiple modules; ~37 files updated). 
- Rewrote `pyproject.toml` to include a proper `[project]` dependency list and added `[project.optional-dependencies]` for `dev` (`pytest`).
- Tightened and pinned runtime/test tooling in `requirements.txt` (added minimal version constraints for `requests`, `matplotlib`, `Pillow`, `numpy`, `fastapi`, `uvicorn`, `pydantic`, `pyserial`, `python-multipart`, `mkdocs`, and `pytest`).
- Cleaned up `README.md` (quick-start code fences, corrected API table rows, removed stray content references, wording tweaks).
- Added GitHub templates: `.github/ISSUE_TEMPLATE/bug_report.md`, `.github/ISSUE_TEMPLATE/feature_request.md`, and `.github/pull_request_template.md`, and normalized issue template config.
- Misc: small adjustments to import usage in controllers/presenters to match the new absolute import style and keep TYPE_CHECKING imports accurate.

### Testing
- No automated tests were executed for this change; `pytest -q` was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983de0b0218833196efc4ae0e8a0cee)