### PR TITLE
docs: add Motivation section to docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,11 +9,24 @@ This documentation is intended for developers working on the SEVA GUI
 
 ## Motivation
 
-SEVA exists to keep GUI interactions with hardware workflows and backend APIs
-predictable, testable, and maintainable. The project solves the common problem
-of UI logic drifting into infrastructure details by enforcing clear MVVM +
-Hexagonal boundaries, so workflow orchestration stays in UseCases and adapters
-own external I/O.
+SEVA was created because the previous GUI was difficult to extend and even
+harder to migrate when device communication changed. Once control moved to
+network-based pyBEEP integration, the UI needed to work reliably with a REST
+API boundary, but the old structure mixed concerns too much to support that
+shift cleanly.
+
+The core goal of this project is pragmatic maintainability: new features should
+be added without rewriting unrelated UI code, and infrastructure changes should
+not force architecture-wide refactors. MVVM + Hexagonal boundaries make that
+possible by keeping Views and ViewModels focused on UI state, moving workflow
+orchestration into UseCases, and isolating all external I/O in adapters.
+
+This also improves diversification and long-term evolution. Through ports and
+adapters, transport/back-end integrations can be swapped more safely (for
+example REST-based integration vs. legacy AMETEK-style paths) while preserving
+GUI workflows. In run execution, server-reported state remains the single source
+of truth for status/progress, which avoids fragile client-side assumptions and
+keeps behavior testable at the use-case boundary.
 
 ## Start here
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,14 @@ This documentation is intended for developers working on the SEVA GUI
 
 > Docs track the `main` branch unless otherwise noted.
 
+## Motivation
+
+SEVA exists to keep GUI interactions with hardware workflows and backend APIs
+predictable, testable, and maintainable. The project solves the common problem
+of UI logic drifting into infrastructure details by enforcing clear MVVM +
+Hexagonal boundaries, so workflow orchestration stays in UseCases and adapters
+own external I/O.
+
 ## Start here
 
 If you are new to the project, follow this order:


### PR DESCRIPTION
### Motivation

- Add a short developer-oriented **Motivation** section near the top of `docs/index.md` that explains why SEVA exists and which problem it solves, with emphasis on enforcing MVVM + Hexagonal boundaries so orchestration belongs in UseCases and external I/O belongs in adapters.

### Description

- Insert a new `## Motivation` section in `docs/index.md` with a brief paragraph describing the project's goal to keep GUI interactions with hardware workflows and backend APIs predictable, testable, and maintainable.
- The change is documentation-only and affects only `docs/index.md` (8 lines inserted).
- Commit message used: `docs: add motivation section to documentation index`.

### Testing

- No runtime or CI tests are required for this docs-only change.
- Verified the change with `git diff -- docs/index.md`, which showed the new section and succeeded.
- Confirmed repository status with `git status --short`, which reported a clean working tree after the commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8517a3c88331a42a96a3f30b5779)