### PR TITLE
Add realistic demo bootstraps for Tk view previews

### DIFF
--- a/seva/app/views/experiment_panel_view.py
+++ b/seva/app/views/experiment_panel_view.py
@@ -352,3 +352,65 @@ class ExperimentPanelView(ttk.Frame):
             var.set("")
         for var in self._flag_vars.values():
             var.set(False)
+
+
+if __name__ == "__main__":
+    def _log_change(field_id: str, value: str) -> None:
+        print(f"[demo] field changed: {field_id}={value}")
+
+    def _log_action(name: str):
+        return lambda: print(f"[demo] action: {name}")
+
+    root = tk.Tk()
+    root.title("ExperimentPanelView Demo")
+    root.geometry("980x720")
+
+    view = ExperimentPanelView(
+        root,
+        on_change=_log_change,
+        on_toggle_control_mode=_log_action("toggle_control_mode"),
+        on_apply_params=_log_action("apply_params"),
+        on_end_task=_log_action("end_task"),
+        on_end_selection=_log_action("end_selection"),
+        on_copy_cv=_log_action("copy_cv"),
+        on_paste_cv=_log_action("paste_cv"),
+        on_copy_dcac=_log_action("copy_dcac"),
+        on_paste_dcac=_log_action("paste_dcac"),
+        on_copy_cdl=_log_action("copy_cdl"),
+        on_paste_cdl=_log_action("paste_cdl"),
+        on_copy_eis=_log_action("copy_eis"),
+        on_paste_eis=_log_action("paste_eis"),
+        on_electrode_mode_changed=lambda mode: print(f"[demo] electrode mode: {mode}"),
+    )
+    view.pack(fill="both", expand=True)
+
+    view.set_editing_well("B14")
+    view.set_electrode_mode("2E")
+    view.set_fields(
+        {
+            "run_cv": True,
+            "cv.vertex1_v": "0.95",
+            "cv.vertex2_v": "-0.20",
+            "cv.final_v": "0.10",
+            "cv.scan_rate_v_s": "0.05",
+            "cv.cycles": "3",
+            "run_dc": True,
+            "run_ac": False,
+            "ea.duration_s": "1800",
+            "ea.charge_cutoff_c": "1.2",
+            "ea.voltage_cutoff_v": "2.4",
+            "ea.frequency_hz": "50",
+            "control_mode": "current (mA)",
+            "ea.target": "12.5",
+            "eval_cdl": True,
+            "cdl.vertex_a_v": "0.10",
+            "cdl.vertex_b_v": "0.30",
+            "run_eis": True,
+            "eis.freq_start_hz": "100000",
+            "eis.freq_end_hz": "0.5",
+            "eis.points": "45",
+            "eis.spacing": "log",
+        }
+    )
+
+    root.mainloop()

--- a/seva/app/views/main_window.py
+++ b/seva/app/views/main_window.py
@@ -351,7 +351,19 @@ class MainWindowView(tk.Tk):
     # ------------------------------------------------------------------
 
 if __name__ == "__main__":
-    # Minimal manual preview (no real callbacks wired). This block can be removed
-    # in production; it is useful during early UI iteration.
-    win = MainWindowView()
+    # Manual preview with visible demo state; regular defaults stay unchanged.
+    win = MainWindowView(
+        on_submit=lambda: print("[demo] Start clicked"),
+        on_cancel_group=lambda: print("[demo] Cancel Group clicked"),
+        on_save_layout=lambda: print("[demo] Save Layout clicked"),
+        on_load_layout=lambda: print("[demo] Load Layout clicked"),
+        on_open_settings=lambda: print("[demo] Settings clicked"),
+        on_open_data_plotter=lambda: print("[demo] Data Plotter clicked"),
+    )
+    win.set_run_group_id("rg-2026-02-10-001")
+    win.set_relay_status("A", "Connected")
+    win.set_relay_status("B", "Timeout")
+    win.set_relay_status("C", "Connected")
+    win.set_status_message("Demo: Run active on 2/3 boxes, polling every 750 ms.")
+    win.show_toast("Demo ready: toolbar callbacks print to console.")
     win.mainloop()

--- a/seva/app/views/runs_panel_view.py
+++ b/seva/app/views/runs_panel_view.py
@@ -172,3 +172,64 @@ class RunsPanelView(ttk.Frame):
 
 
 __all__ = ["RunsPanelView"]
+
+
+if __name__ == "__main__":
+    from dataclasses import dataclass
+
+    @dataclass
+    class _DemoRunRow:
+        group_id: str
+        name: str
+        status: str
+        progress: str
+        boxes: str
+        started_at: str
+        download_path: str
+
+    root = tk.Tk()
+    root.title("RunsPanelView Demo")
+    root.geometry("1180x420")
+
+    panel = RunsPanelView(root)
+    panel.pack(fill="both", expand=True)
+
+    panel.on_open = lambda gid: print(f"[demo] open folder for {gid}")
+    panel.on_cancel = lambda gid: print(f"[demo] cancel requested for {gid}")
+    panel.on_delete = lambda gid: print(f"[demo] delete requested for {gid}")
+    panel.on_select = lambda gid: print(f"[demo] selected {gid}")
+
+    panel.set_rows(
+        [
+            _DemoRunRow(
+                group_id="rg-2026-02-10-001",
+                name="Ni foam CO2RR screening",
+                status="running",
+                progress="62%",
+                boxes="A,B",
+                started_at="2026-02-10 09:14",
+                download_path="/data/seva/runs/rg-2026-02-10-001",
+            ),
+            _DemoRunRow(
+                group_id="rg-2026-02-09-003",
+                name="HER stability long run",
+                status="completed",
+                progress="100%",
+                boxes="C",
+                started_at="2026-02-09 16:40",
+                download_path="/data/seva/runs/rg-2026-02-09-003",
+            ),
+            _DemoRunRow(
+                group_id="rg-2026-02-08-002",
+                name="EIS baseline check",
+                status="failed",
+                progress="37%",
+                boxes="D",
+                started_at="2026-02-08 11:05",
+                download_path="",
+            ),
+        ]
+    )
+    panel.select_group("rg-2026-02-10-001")
+
+    root.mainloop()

--- a/seva/app/views/settings_dialog.py
+++ b/seva/app/views/settings_dialog.py
@@ -440,5 +440,48 @@ class SettingsDialog(tk.Toplevel):
 
 if __name__ == "__main__":
     root = tk.Tk()
-    dialog = SettingsDialog(root)
+    root.title("SettingsDialog Demo Host")
+    root.geometry("900x700")
+
+    dialog = SettingsDialog(
+        root,
+        on_test_connection=lambda box: print(f"[demo] test connection for box {box}"),
+        on_test_relay=lambda: print("[demo] test relay"),
+        on_browse_results_dir=lambda: print("[demo] browse results dir"),
+        on_browse_firmware=lambda: print("[demo] browse firmware"),
+        on_discover_devices=lambda: print("[demo] discover devices"),
+        on_open_nas_setup=lambda: print("[demo] open NAS setup"),
+        on_save=lambda payload: print(f"[demo] save payload with {len(payload)} keys"),
+        on_flash_firmware=lambda: print("[demo] flash firmware"),
+        on_close=lambda: print("[demo] close dialog"),
+    )
+
+    dialog.set_api_base_urls(
+        {
+            "A": "http://10.0.10.21:8000/api/v1",
+            "B": "http://10.0.10.22:8000/api/v1",
+            "C": "http://10.0.10.23:8000/api/v1",
+            "D": "http://10.0.10.24:8000/api/v1",
+        }
+    )
+    dialog.set_api_keys(
+        {
+            "A": "sk_live_demo_box_a",
+            "B": "sk_live_demo_box_b",
+            "C": "sk_live_demo_box_c",
+            "D": "sk_live_demo_box_d",
+        }
+    )
+    dialog.set_timeouts(request_s=12, download_s=180)
+    dialog.set_poll_interval(750)
+    dialog.set_poll_backoff_max(5000)
+    dialog.set_results_dir("/data/seva/results")
+    dialog.set_experiment_name("CO2RR_CuFoam_Screening")
+    dialog.set_subdir("2026-02-10_batch-A")
+    dialog.set_auto_download(True)
+    dialog.set_use_streaming(True)
+    dialog.set_debug_logging(False)
+    dialog.set_relay_config(ip="10.0.10.40", port=502)
+    dialog.set_firmware_path("/opt/seva/firmware/potentiostat_v2.3.1.bin")
+
     dialog.mainloop()

--- a/seva/app/views/well_grid_view.py
+++ b/seva/app/views/well_grid_view.py
@@ -287,6 +287,23 @@ class WellGridView(ttk.Frame):
     # ------------------------------------------------------------------
 if __name__ == "__main__":
     root = tk.Tk()
-    grid = WellGridView(root, boxes=("A", "B", "C","D","E","F"))
+    root.title("WellGridView Demo")
+    root.geometry("980x520")
+
+    grid = WellGridView(
+        root,
+        boxes=("A", "B", "C", "D"),
+        on_select_wells=lambda wells: print(f"[demo] selected wells: {sorted(wells)}"),
+        on_toggle_enable_selected=lambda: print("[demo] toggle enable for selected wells"),
+        on_copy_params_from=lambda well: print(f"[demo] copy params from {well}"),
+        on_paste_params_to_selection=lambda: print("[demo] paste params to selection"),
+        on_reset_selected=lambda: print("[demo] reset selected wells"),
+        on_reset_all=lambda: print("[demo] reset all wells"),
+        on_open_plot=lambda well: print(f"[demo] open plot for {well}"),
+    )
     grid.pack(fill="both", expand=True)
+
+    grid.set_configured_wells({"A1", "A2", "A5", "B11", "B13", "C23", "D36"})
+    grid.set_selection({"A2", "B11", "C23"})
+
     root.mainloop()


### PR DESCRIPTION
### Motivation
- Provide richer, visible demo data for Tkinter view previews so developers can visually inspect and interact with realistic UI states during manual iteration without changing normal runtime defaults.

### Description
- Added a standalone `if __name__ == "__main__":` demo block to `seva/app/views/experiment_panel_view.py` that creates a Tk root, wires dummy callbacks, and populates realistic example fields via `set_fields`, `set_editing_well`, and `set_electrode_mode`.
- Added a standalone demo block to `seva/app/views/runs_panel_view.py` that builds typed demo rows, wires `on_open`/`on_cancel`/`on_delete`/`on_select` callbacks, populates the runs table via `set_rows`, and pre-selects a row with `select_group`.
- Expanded existing demo sections in `seva/app/views/main_window.py`, `seva/app/views/settings_dialog.py`, and `seva/app/views/well_grid_view.py` to set visible demo state (example run id, relay statuses, status/toast text; example API URLs, timeouts/poll intervals, storage/relay/firmware values; configured and selected wells) and to use dummy callbacks, exclusively via public setters and hooks.
- All demo data is confined to `__main__` blocks so normal imports and default behavior remain unchanged.

### Testing
- Compiled the modified view modules with `python -m compileall seva/app/views/experiment_panel_view.py seva/app/views/runs_panel_view.py seva/app/views/main_window.py seva/app/views/settings_dialog.py seva/app/views/well_grid_view.py`, which completed successfully.
- No automated GUI tests were run because the changes add demo-only `__main__` preview blocks intended for manual inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a851356b0833195b83d2863bf24fe)