### PR TITLE
Normalize app-layer imports for IDE-friendly GUI startup

### DIFF
--- a/seva/app/controller.py
+++ b/seva/app/controller.py
@@ -9,20 +9,20 @@ from __future__ import annotations
 
 from typing import Optional
 
-from ..adapters.device_rest import DeviceRestAdapter
-from ..adapters.firmware_rest import FirmwareRestAdapter
-from ..adapters.job_rest import JobRestAdapter
-from ..usecases.cancel_group import CancelGroup
-from ..usecases.download_group_results import DownloadGroupResults
-from ..usecases.flash_firmware import FlashFirmware
-from ..usecases.poll_device_status import PollDeviceStatus
-from ..usecases.poll_group_status import PollGroupStatus
-from ..usecases.start_experiment_batch import StartExperimentBatch
-from ..usecases.test_connection import TestConnection
-from ..viewmodels.settings_vm import SettingsVM
+from seva.adapters.device_rest import DeviceRestAdapter
+from seva.adapters.firmware_rest import FirmwareRestAdapter
+from seva.adapters.job_rest import JobRestAdapter
+from seva.usecases.cancel_group import CancelGroup
+from seva.usecases.download_group_results import DownloadGroupResults
+from seva.usecases.flash_firmware import FlashFirmware
+from seva.usecases.poll_device_status import PollDeviceStatus
+from seva.usecases.poll_group_status import PollGroupStatus
+from seva.usecases.start_experiment_batch import StartExperimentBatch
+from seva.usecases.test_connection import TestConnection
+from seva.viewmodels.settings_vm import SettingsVM
 
 try:
-    from ..usecases.cancel_runs import CancelRuns as _CancelRunsClass
+    from seva.usecases.cancel_runs import CancelRuns as _CancelRunsClass
 except ImportError:
     _CancelRunsClass = None
 

--- a/seva/app/discovery_controller.py
+++ b/seva/app/discovery_controller.py
@@ -17,10 +17,10 @@ from seva.usecases.discover_and_assign_devices import (
 )
 from seva.viewmodels.settings_vm import SettingsVM
 from seva.domain.ports import StoragePort
-from .views.discovery_results_dialog import DiscoveryResultsDialog
+from seva.app.views.discovery_results_dialog import DiscoveryResultsDialog
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .views.settings_dialog import SettingsDialog
+    from seva.app.views.settings_dialog import SettingsDialog
 
 
 class DiscoveryController:

--- a/seva/app/main.py
+++ b/seva/app/main.py
@@ -38,47 +38,54 @@ from datetime import datetime
 from tkinter import filedialog
 from typing import Dict, Set, Optional, List, TYPE_CHECKING
 
+if __package__ in (None, ""):
+    # Support direct script execution (e.g., IDE "Run file") by ensuring the
+    # repository root is importable before absolute package imports are used.
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
 # ---- Views (UI-only) ----
-from .views.main_window import MainWindowView
-from .views.well_grid_view import WellGridView
-from .views.experiment_panel_view import ExperimentPanelView
-from .views.run_overview_view import RunOverviewView
-from .views.channel_activity_view import ChannelActivityView
-from .views.settings_dialog import SettingsDialog
-from .dataplotter_standalone import DataProcessingGUI
-from .discovery_controller import DiscoveryController
-from .settings_controller import SettingsController
-from .download_controller import DownloadController
-from .views.runs_panel_view import RunsPanelView
+from seva.app.views.main_window import MainWindowView
+from seva.app.views.well_grid_view import WellGridView
+from seva.app.views.experiment_panel_view import ExperimentPanelView
+from seva.app.views.run_overview_view import RunOverviewView
+from seva.app.views.channel_activity_view import ChannelActivityView
+from seva.app.views.settings_dialog import SettingsDialog
+from seva.app.dataplotter_standalone import DataProcessingGUI
+from seva.app.discovery_controller import DiscoveryController
+from seva.app.settings_controller import SettingsController
+from seva.app.download_controller import DownloadController
+from seva.app.views.runs_panel_view import RunsPanelView
 
 # ---- ViewModels ----
-from ..viewmodels.plate_vm import PlateVM
-from ..viewmodels.experiment_vm import ExperimentVM
-from ..viewmodels.progress_vm import ProgressVM
-from ..viewmodels.settings_vm import SettingsVM, BOX_IDS
-from ..viewmodels.live_data_vm import LiveDataVM
-from ..viewmodels.runs_vm import RunsVM
+from seva.viewmodels.plate_vm import PlateVM
+from seva.viewmodels.experiment_vm import ExperimentVM
+from seva.viewmodels.progress_vm import ProgressVM
+from seva.viewmodels.settings_vm import SettingsVM, BOX_IDS
+from seva.viewmodels.live_data_vm import LiveDataVM
+from seva.viewmodels.runs_vm import RunsVM
 
 # ---- UseCases & Adapter ----
-from .run_flow_presenter import RunFlowPresenter
-from ..adapters.storage_local import StorageLocal
-from ..adapters.discovery_http import HttpDiscoveryAdapter
-from ..adapters.relay_mock import RelayMock
-from ..usecases.save_plate_layout import SavePlateLayout
-from ..usecases.load_plate_layout import LoadPlateLayout
-from ..usecases.build_experiment_plan import BuildExperimentPlan
-from ..usecases.build_storage_meta import BuildStorageMeta
-from ..domain.runs_registry import RunsRegistry
-from ..domain.ports import UseCaseError
-from ..usecases.test_relay import TestRelay
-from ..usecases.set_electrode_mode import SetElectrodeMode
-from ..usecases.discover_devices import DiscoverDevices, MergeDiscoveredIntoRegistry
-from ..usecases.discover_and_assign_devices import DiscoverAndAssignDevices
-from ..utils import logging as logging_utils
-from .controller import AppController
+from seva.app.run_flow_presenter import RunFlowPresenter
+from seva.adapters.storage_local import StorageLocal
+from seva.adapters.discovery_http import HttpDiscoveryAdapter
+from seva.adapters.relay_mock import RelayMock
+from seva.usecases.save_plate_layout import SavePlateLayout
+from seva.usecases.load_plate_layout import LoadPlateLayout
+from seva.usecases.build_experiment_plan import BuildExperimentPlan
+from seva.usecases.build_storage_meta import BuildStorageMeta
+from seva.domain.runs_registry import RunsRegistry
+from seva.domain.ports import UseCaseError
+from seva.usecases.test_relay import TestRelay
+from seva.usecases.set_electrode_mode import SetElectrodeMode
+from seva.usecases.discover_devices import DiscoverDevices, MergeDiscoveredIntoRegistry
+from seva.usecases.discover_and_assign_devices import DiscoverAndAssignDevices
+from seva.utils import logging as logging_utils
+from seva.app.controller import AppController
 
 if TYPE_CHECKING:
-    from ..usecases.cancel_runs import CancelRuns
+    from seva.usecases.cancel_runs import CancelRuns
 
 logging_utils.configure_root()
 

--- a/seva/app/run_flow_presenter.py
+++ b/seva/app/run_flow_presenter.py
@@ -44,8 +44,8 @@ from seva.viewmodels.runs_vm import RunsVM
 from seva.viewmodels.settings_vm import SettingsVM
 from seva.app.polling_scheduler import PollingScheduler
 
-from .controller import AppController
-from ..adapters.storage_local import StorageLocal
+from seva.app.controller import AppController
+from seva.adapters.storage_local import StorageLocal
 
 
 @dataclass


### PR DESCRIPTION
### Motivation
- Running GUI entrypoints directly from an IDE can fail due to relative imports that require package execution context, so app-layer modules must use absolute `seva.*` imports to be robust for both package and direct-script execution.
- Maintain the existing runtime behavior while removing fragile relative import paths that break IDE "Run file" workflows.

### Description
- Added a small `sys.path` injection in `seva/app/main.py` when `__package__` is empty so absolute `seva.*` imports resolve during direct script execution.
- Replaced relative imports with absolute `seva.*` imports in `seva/app/controller.py`, including the optional `_CancelRunsClass` import for type/feature detection.
- Replaced relative imports with absolute `seva.*` imports in `seva/app/discovery_controller.py`, including the `TYPE_CHECKING` type reference.
- Replaced relative imports with absolute `seva.*` imports in `seva/app/run_flow_presenter.py` to align presenter wiring with the updated composition root.

### Testing
- No automated tests were executed for this change because it is import-only and changes are limited to module import paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69851e61919c8331bef0f3969e8013d2)