### PR TITLE
docs: add REST API setup tutorial and restart instructions

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -50,13 +50,17 @@ cd rest_api
 uvicorn app:app --host 0.0.0.0 --port 8000
 ```
 
-### REST API environment variables
+For a full setup tutorial (installation, env vars, smoke tests, NAS/SMB checks,
+and restart procedures), see:
 
-You can customize the API with these environment variables:
+- **[REST API Setup Tutorial](rest-api-setup.md)**
+
+### REST API environment variables (quick reference)
 
 - `RUNS_ROOT`: Root directory where run data is stored. Defaults to `/opt/box/runs`.
 - `BOX_API_KEY`: Optional API key for securing requests.
 - `BOX_ID`: Identifier for the box (used in health/device responses).
+- `NAS_CONFIG_PATH`: Optional path for NAS/SMB configuration persistence.
 - `BOX_BUILD` / `BOX_BUILD_ID`: Optional build metadata for versioning.
 
 Example:

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,11 +34,12 @@ If you are new to the project, follow this order:
 
 1. Read **What is this repo?** (below) to understand the scope.
 2. Set up your environment in **[Development Setup](dev-setup.md)**.
-3. Review the **[Architecture Overview](architecture_overview.md)** to learn the MVVM + Hexagonal boundaries.
-4. Work through the **[MVVM + Hexagonal Tutorial Notebooks](mvvm_tutorial_notebooks.md)** for a guided architecture walkthrough.
-5. Explore the **[SEVA GUI workflows](workflows_seva.md)** and **[REST API workflows](workflows_rest_api.md)**.
-6. Use **[Troubleshooting](troubleshooting.md)** and the **[Glossary](glossary.md)** when you get stuck.
-7. Review the **[ChatGPT Codex Guide](codex_guide.md)** for AI-assisted changes.
+3. Configure/deploy the API with **[REST API Setup Tutorial](rest-api-setup.md)**.
+4. Review the **[Architecture Overview](architecture_overview.md)** to learn the MVVM + Hexagonal boundaries.
+5. Work through the **[MVVM + Hexagonal Tutorial Notebooks](mvvm_tutorial_notebooks.md)** for a guided architecture walkthrough.
+6. Explore the **[SEVA GUI workflows](workflows_seva.md)** and **[REST API workflows](workflows_rest_api.md)**.
+7. Use **[Troubleshooting](troubleshooting.md)** and the **[Glossary](glossary.md)** when you get stuck.
+8. Review the **[ChatGPT Codex Guide](codex_guide.md)** for AI-assisted changes.
 
 ### What is this repo?
 
@@ -52,8 +53,8 @@ Follow the steps in **[Development Setup](dev-setup.md)** to configure Python an
 
 ### How to run REST API locally (Linux/Raspberry Pi)
 
-See **[Development Setup](dev-setup.md)** for Linux/Raspberry Pi-specific instructions
-for the FastAPI service.
+See **[REST API Setup Tutorial](rest-api-setup.md)** for the complete Linux/Raspberry Pi setup,
+including install, verification, and restart steps.
 
 ### Where to change what? (View vs ViewModel vs UseCase)
 
@@ -79,10 +80,11 @@ It does **not** document UI usage for end users.
 Follow this order for a linear tour through the docs:
 
 1. **[Development Setup](dev-setup.md)** (local environment + run GUI/API)
-2. **[Architecture Overview](architecture_overview.md)** (MVVM + Hexagonal boundaries)
-3. **[MVVM + Hexagonal Tutorial Notebooks](mvvm_tutorial_notebooks.md)**
-4. **[SEVA GUI workflows](workflows_seva.md)**
-5. **[REST API workflows](workflows_rest_api.md)**
-6. **[Troubleshooting](troubleshooting.md)**
-7. **[Glossary](glossary.md)**
-8. **[ChatGPT Codex Guide](codex_guide.md)**
+2. **[REST API Setup Tutorial](rest-api-setup.md)** (API install, env, smoke tests, restart)
+3. **[Architecture Overview](architecture_overview.md)** (MVVM + Hexagonal boundaries)
+4. **[MVVM + Hexagonal Tutorial Notebooks](mvvm_tutorial_notebooks.md)**
+5. **[SEVA GUI workflows](workflows_seva.md)**
+6. **[REST API workflows](workflows_rest_api.md)**
+7. **[Troubleshooting](troubleshooting.md)**
+8. **[Glossary](glossary.md)**
+9. **[ChatGPT Codex Guide](codex_guide.md)**

--- a/docs/rest-api-setup.md
+++ b/docs/rest-api-setup.md
@@ -1,0 +1,151 @@
+# REST API Setup Tutorial (Linux/Raspberry Pi)
+
+This guide focuses on setting up and operating the FastAPI service in
+`rest_api/`.
+
+Use this page if you want to:
+
+- install a fresh REST API environment,
+- configure runtime variables safely,
+- run health checks before connecting the GUI,
+- and restart the API cleanly after changes.
+
+## 1) Platform and prerequisites
+
+Recommended target: Linux/Raspberry Pi.
+
+- Python 3.10–3.12
+- Git
+- Network access for dependency install (or a prepared offline wheelhouse)
+
+For NAS/SMB workflows, Linux system tools are also required:
+
+- `mount` with CIFS support (`cifs-utils` package on many distros)
+- `rsync`
+
+## 2) Install dependencies
+
+From repository root:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install -r requirements.txt
+```
+
+### Reproducible pyBEEP installs (offline/vendor note)
+
+`requirements.txt` currently pins pyBEEP from a Git URL. For environments
+without internet access, vendor pyBEEP in-repo and install it from a local
+path (the file already contains a commented local editable example).
+
+## 3) Configure environment variables
+
+The API reads configuration from environment variables at startup.
+
+- `BOX_API_KEY` (optional): if set, every protected request must send
+  `X-API-Key`.
+- `BOX_ID` (optional): identifier returned by `/health`.
+- `RUNS_ROOT` (optional): run output root directory, default `/opt/box/runs`.
+- `NAS_CONFIG_PATH` (optional): SMB config path,
+  default `/opt/box/nas_smb.json`.
+- `BOX_BUILD` / `BOX_BUILD_ID` (optional): build metadata for `/version`.
+
+Example:
+
+```bash
+export BOX_API_KEY="change-me"
+export BOX_ID="lab-box-01"
+export RUNS_ROOT="/opt/box/runs"
+export NAS_CONFIG_PATH="/opt/box/nas_smb.json"
+```
+
+## 4) Start the REST API
+
+Run from the REST API directory:
+
+```bash
+cd rest_api
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+Interactive OpenAPI docs are available at:
+
+- `http://<host>:8000/docs`
+
+## 5) Smoke test after startup
+
+Use these checks before connecting the GUI.
+
+Without API key:
+
+```bash
+curl http://localhost:8000/health
+curl http://localhost:8000/devices
+curl http://localhost:8000/modes
+```
+
+With API key:
+
+```bash
+curl -H "X-API-Key: $BOX_API_KEY" http://localhost:8000/health
+curl -H "X-API-Key: $BOX_API_KEY" http://localhost:8000/devices
+curl -H "X-API-Key: $BOX_API_KEY" http://localhost:8000/modes
+```
+
+## 6) Restarting the REST API
+
+### A) If running in a terminal
+
+1. Stop the server with `Ctrl+C`.
+2. Ensure your virtualenv/environment variables are still active.
+3. Start again:
+
+```bash
+cd rest_api
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+### B) If running as a `systemd` service
+
+```bash
+sudo systemctl restart pybeep-box.service
+sudo systemctl status pybeep-box.service --no-pager
+```
+
+Optional live logs:
+
+```bash
+sudo journalctl -u pybeep-box.service -f
+```
+
+## 7) Optional NAS/SMB setup check (Linux)
+
+Configure once:
+
+```bash
+curl -X POST http://localhost:8000/nas/setup \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $BOX_API_KEY" \
+  -d '{
+        "host": "nas.local",
+        "share": "experiments",
+        "username": "lab",
+        "password": "***",
+        "base_subdir": "projectA/line2",
+        "retention_days": 14
+      }'
+```
+
+Check connectivity:
+
+```bash
+curl -H "X-API-Key: $BOX_API_KEY" http://localhost:8000/nas/health
+```
+
+## 8) Related docs
+
+- [Development Setup](dev-setup.md) for overall GUI + API onboarding.
+- [REST API Workflows](workflows_rest_api.md) for end-to-end request flows.
+- [Troubleshooting](troubleshooting.md) for common issues and logging tips.

--- a/docs/workflows_rest_api.md
+++ b/docs/workflows_rest_api.md
@@ -2,6 +2,8 @@
 
 This document captures the end-to-end workflows that GUI code triggers in the REST API.
 
+For installation, environment variables, startup checks, and restart procedures, see **[REST API Setup Tutorial](rest-api-setup.md)**.
+
 ## GUI caller map
 
 - `seva/adapters/device_rest.py` -> discovery and mode metadata endpoints.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Development Setup: dev-setup.md
+  - REST API Setup Tutorial: rest-api-setup.md
   - Architecture Overview: architecture_overview.md
   - MVVM + Hexagonal Tutorial Notebooks: mvvm_tutorial_notebooks.md
   - SEVA GUI Workflows: workflows_seva.md


### PR DESCRIPTION
### Motivation

- Provide a dedicated, practical guide for installing, configuring, starting, smoke-testing, and restarting the FastAPI-based REST API on Linux/Raspberry Pi instead of mixing setup steps into workflow docs. 
- Make it explicit where developers should look for environment variables, startup commands, and `systemd` restart instructions so GUI authors and on-device operators can reliably bring the API up and back online. 

### Description

- Add `docs/rest-api-setup.md` which documents prerequisites, dependency install, environment variables, startup commands, smoke tests, optional NAS/SMB checks, and restart procedures for both terminal runs and `systemd` service-managed deployments. 
- Update `docs/dev-setup.md` to reference the new setup tutorial and add `NAS_CONFIG_PATH` to the quick environment-variable reference. 
- Update `docs/index.md` to surface the new tutorial in the onboarding "Start here" flow and documentation map. 
- Add a forward-link from `docs/workflows_rest_api.md` to the new tutorial and register the page in `mkdocs.yml` navigation. 

### Testing

- Confirmed references and wiring with `rg` searches for `REST API Setup Tutorial`, `rest-api-setup.md`, `NAS_CONFIG_PATH`, and restart guidance which all returned expected matches. 
- Verified repository changes were staged and committed (`git` status and commit recorded). 
- Attempted `mkdocs build -q` to validate the site, but it failed in this environment because `mkdocs` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aa146d9308331bc351149cb36416f)