### PR TITLE
Align Python runtime metadata with code-based minimum version (3.10+)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "SEVA GUI MVVM — Electrochemistry client and Raspberry Pi Box AP
 readme = "README.md"
 license = { text = "MIT" }
 authors = [{ name = "SEVA Team" }]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10"
 keywords = ["electrochemistry", "mvvm", "fastapi", "tkinter", "pyBEEP"]
 dependencies = [
   "requests",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# Python runtime
+# Code uses Python 3.10+ syntax/features (e.g. match/case, PEP 604 unions).
+# Keep environments on Python >=3.10.
+
 # GUI / Client
 requests>=2.31
 matplotlib>=3.7


### PR DESCRIPTION
### Motivation
- Align package metadata with the repository's actual use of Python 3.10+ language features and remove an unnecessary hard upper bound that could block newer patch/minor releases.

### Description
- Update `pyproject.toml` to `requires-python = ">=3.10"` and prepend a short runtime note to `requirements.txt` that the codebase targets Python 3.10+ (e.g. `match/case`, PEP 604 unions).

### Testing
- Ran `python --version` and `python -m py_compile seva/domain/layout_utils.py rest_api/app.py vendor/pyBEEP/src/pyBEEP/controller.py` which succeeded, and attempted to parse `pyproject.toml` with `tomllib` which failed because `tomllib` is only available on Python ≥3.11.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ccb8d43908331af04de9dedd3460d)