### PR TITLE
Update Codex guide with docs maintenance expectations and explain YAGNI/KISS/DRY

### DIFF
--- a/docs/codex_guide.md
+++ b/docs/codex_guide.md
@@ -102,7 +102,7 @@ Recommended approach:
 - run multiple plan-review cycles before coding,
 - ask Codex to ask questions and challenge assumptions,
 - for larger refactors, optionally reference `.agent/PLANS.md`,
-- update affected documentation in `docs/` when behavior, workflows, or interfaces change.
+- ask to update affected documentation in `docs/` when behavior, workflows, or interfaces change.
 
 Important experience-based guidance:
 
@@ -130,7 +130,7 @@ If requirements are vague, use planning iterations to converge:
 
 If requirements are clear, provide explicit implementation guidance (layer ownership, contracts, validation).
 
-For feature work, keep documentation in `docs/` up to date whenever user-facing behavior, workflows, setup steps, or interfaces are changed.
+For feature work, keep documentation in `docs/` up to date whenever user-facing behavior, workflows, setup steps, or interfaces are changed. Use the same Chat to keep context.
 
 Global simplicity rule for feature work and refactors:
 

--- a/docs/codex_guide.md
+++ b/docs/codex_guide.md
@@ -1,81 +1,178 @@
-# ChatGPT Codex Guide
+# ChatGPT Codex User Guide (SEVA GUI MVVM)
 
-This guide shows how to use ChatGPT Codex effectively on this repository. It is
-aimed at Python developers who are new to the codebase and want reliable,
-architecture-safe changes.
+This document is a formal guide for developers who want to use ChatGPT Codex effectively in this repository.
 
-## Architecture guardrails to mention in prompts
+It focuses on practical collaboration: selecting the correct repository context, planning work, implementing safely, validating changes, and iterating through pull requests.
 
-- **Views**: UI/rendering only. No I/O, no domain rules, no mapping.
-- **ViewModels**: UI state + commands only. No network/filesystem I/O.
-- **UseCases**: Orchestrate workflows, call ports.
-- **Adapters**: Implement ports for I/O (HTTP, filesystem, discovery).
-- **Domain types**: Use domain objects instead of raw dict/JSON above adapters.
+## 1. Repository Context and Governing Documents
 
-These rules help Codex avoid putting logic in the wrong layer.
+### 1.1 Read `AGENTS.md` first (required)
 
-## Prompting checklist
+Before requesting code changes, read `AGENTS.md` once to understand repository guardrails. It already covers:
 
-Before asking for code changes, include:
+- MVVM + Hexagonal layer boundaries,
+- domain objects vs. raw dict/JSON above adapters,
+- error propagation policy,
+- avoidance of legacy fallback paths,
+- testing direction.
 
-1. **Goal** (what you want to change).
-2. **Scope** (which folders/files are relevant).
-3. **Architecture rules** (MVVM + Hexagonal boundaries above).
-4. **Constraints**:
-   - Avoid defensive programming for unlikely scenarios.
-   - Avoid KISS/YAGNI/DRY slogans as substitutes for reasoning.
-   - Provide a plan before coding.
-   - Prefer minimal, explicit changes with clear call chains.
+Because this is already documented centrally, you do not need to restate all architecture boundaries in every prompt.
 
-## Suggested prompt template
+### 1.2 Use `.agent/PLANS.md` when needed (optional, situation-dependent)
 
-```
-Goal:
-  Add/modify <feature> in the SEVA GUI.
+Reading `.agent/PLANS.md` is optional for small or straightforward work.
 
-Scope:
-  - Relevant areas: seva/app/*, seva/viewmodels/*, seva/usecases/*, seva/adapters/*
-  - Ignore UI end-user docs.
+Use it when work is large, cross-cutting, risky, or unclear (for example major refactors, architecture-impacting features, or complex migrations).
 
-Architecture rules:
-  - Views are UI-only, no I/O.
-  - ViewModels are state/commands only, no network/filesystem I/O.
-  - UseCases orchestrate workflows and call ports.
-  - Adapters implement ports for I/O.
-  - Use domain objects above adapters.
+### 1.3 Update guardrails over time (recommended)
 
-Constraints:
-  - Avoid defensive coding for unlikely paths.
-  - No KISS/YAGNI/DRY slogans; explain tradeoffs instead.
-  - Produce a plan first, then implement.
+It can be useful to refine `AGENTS.md` as team understanding evolves, for example:
 
-Context:
-  - Link: docs/architecture_overview.md
-  - Link: docs/workflows_seva.md
-  - Link: docs/classes_seva.md
-```
+- before a large refactor,
+- after long periods without updates,
+- when recurring review issues appear.
 
-## Example prompt
+## 2. Quickstart Workflow (Web)
 
-```
-Goal:
-  Add a new "Export Summary" action that saves a CSV from the run overview.
+Use this operational flow when working with Codex in the web interface.
 
-Scope:
-  - GUI: seva/app/views/run_overview_view.py
-  - ViewModel: seva/viewmodels/runs_vm.py
-  - UseCase: seva/usecases/export_summary.py
-  - Adapter: seva/adapters/storage_local.py
+1. Select repository and target branch.
+2. Ask your implementation or analysis question.
+3. Review generated plan and code changes.
+4. Let Codex create a pull request.
+5. Test the branch independently.
+6. Decide next action:
+   - merge branch,
+   - make additional manual commits,
+   - or continue improving with Codex and update the branch.
 
-Architecture rules:
-  - Views are UI-only, no I/O.
-  - ViewModels are state/commands only, no network/filesystem I/O.
-  - UseCases orchestrate workflows and call ports.
-  - Adapters implement ports for I/O.
-  - Use domain objects above adapters.
+This workflow should be your default working model.
 
-Constraints:
-  - Avoid defensive coding for unlikely paths.
-  - No KISS/YAGNI/DRY slogans; explain tradeoffs instead.
-  - Produce a plan first, then implement.
-```
+## 3. Prompting Standard: Required vs Optional Inputs
+
+Use this structure to communicate with Codex.
+
+### 3.1 Required
+
+- **Goal/outcome**: what should work after the change?
+- **Scope/context**: which files, modules, or user flows are relevant?
+- **Constraints/non-goals**: what must remain unchanged?
+
+### 3.2 Optional but helpful
+
+- touched files to prioritize,
+- risk points to watch,
+- validation strategy expectations,
+- requirement that Codex asks clarifying questions before implementation.
+
+Recommended instruction to include when requirements are unclear:
+
+- “Before implementing, ask clarifying questions until ambiguity is low.”
+
+## 4. Practical Task Workflows
+
+### 4.1 Bugfix Workflow
+
+Start from evidence first:
+
+- provide a GUI screenshot,
+- provide a terminal screenshot,
+- or paste direct terminal output.
+
+Then work iteratively with Codex:
+
+- ask where Codex thinks the issue originates,
+- request likely root causes and candidate fixes,
+- if you already have hypotheses, provide them and refine direction together.
+
+Important practice note:
+
+- Codex can sometimes produce symptom-level fixes (“band-aid fixes”).
+- Ask explicitly for a deep/root-cause fix when needed.
+- Final confidence still comes from testing and code familiarity.
+
+This pattern often works very well for smaller fixes.
+
+### 4.2 Refactor Workflow
+
+For refactors, planning iterations are critical.
+
+Recommended approach:
+
+- run multiple plan-review cycles before coding,
+- ask Codex to ask questions and challenge assumptions,
+- for larger refactors, optionally reference `.agent/PLANS.md`,
+- update affected documentation in `docs/` when behavior, workflows, or interfaces change.
+
+Important experience-based guidance:
+
+- Codex may introduce unnecessary fallback paths.
+- Codex may re-implement helpers that already exist.
+
+To reduce this risk, instruct explicitly:
+
+- “Scan the relevant codebase deeply before proposing refactor steps.”
+- “Search for existing helpers/utilities before creating new ones.”
+- “Do not introduce fallback branches unless explicitly required.”
+
+### 4.3 Feature Implementation Workflow
+
+Feature work can start in two valid modes:
+
+- **exploratory mode**: requirements are still vague,
+- **specified mode**: architecture and expected flow are already known.
+
+If requirements are vague, use planning iterations to converge:
+
+- start broad,
+- refine design through questions/answers,
+- then implement once direction is stable.
+
+If requirements are clear, provide explicit implementation guidance (layer ownership, contracts, validation).
+
+For feature work, keep documentation in `docs/` up to date whenever user-facing behavior, workflows, setup steps, or interfaces are changed.
+
+Global simplicity rule for feature work and refactors:
+
+- apply **YAGNI** (*You Aren't Gonna Need It*: avoid building speculative functionality),
+- apply **KISS** (*Keep It Simple, Stupid*: prefer the simplest solution that satisfies current requirements),
+- apply **DRY** (*Don't Repeat Yourself*: reuse existing logic instead of duplicating behavior),
+- ask Codex to review a broad file set during planning to avoid local optimization and overengineering.
+
+## 5. Common Failure Modes in Practice
+
+Watch for these recurring issues:
+
+- implementing too quickly without clarifying uncertainty,
+- solving symptoms instead of root causes,
+- duplicating existing helpers/utilities,
+- adding unnecessary fallback/legacy logic,
+- overengineering simple requirements,
+- validating too little before merge.
+
+When one of these appears, return to planning and request targeted clarification.
+
+## 6. How to Steer Codex During Planning Iterations
+
+Use concise steering instructions such as:
+
+- “Propose an initial plan and list open questions first.”
+- “Identify uncertainties and ask me what you need before coding.”
+- “Review more files before finalizing architecture decisions.”
+- “Prefer existing helpers over new abstractions when possible.”
+- “Prioritize a deep fix over a temporary symptom patch.”
+- “Keep solution simple (YAGNI/KISS/DRY), avoid overengineering.”
+
+A short, explicit steering message is usually enough to improve output quality significantly.
+
+## 7. Decision Checklist Before Merge
+
+Before merging a Codex-generated branch, confirm:
+
+- [ ] behavior is correct in your own branch testing,
+- [ ] no obvious fallback/legacy detours were introduced,
+- [ ] existing helpers were reused where appropriate,
+- [ ] complexity is justified and not overengineered,
+- [ ] follow-up improvements are documented if needed.
+
+If these checks fail, iterate on the same branch with Codex or make targeted manual commits before merge.


### PR DESCRIPTION
### Motivation

- Make the Codex guidance explicit that feature work and refactors which change behavior, workflows, or interfaces must update repository documentation under `docs/`.
- Reduce misunderstandings by expanding the simplicity guardrail with short, actionable definitions for **YAGNI**, **KISS**, and **DRY**.

### Description

- Added a reminder in the Refactor Workflow that affected documentation in `docs/` must be updated when behavior, workflows, or interfaces change.
- Added a matching reminder in the Feature Implementation Workflow to keep `docs/` up to date for user-facing behavior, workflows, setup steps, or interfaces.
- Expanded the global simplicity guidance to include brief in-line definitions for `YAGNI`, `KISS`, and `DRY` and preserved the existing planning advice.

### Testing

- Ran repository checks: `git diff --check` completed with no issues.
- Verified working tree status with `git status --short` to confirm the documentation-only change is present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd91075e483319ad1f445d85d39f8)