### PR TITLE
Refactor device discovery to IPv4 mDNS/Zeroconf end-to-end

### DIFF
--- a/.agent/execplans/2026-02-18-mdns-discovery-revamp.md
+++ b/.agent/execplans/2026-02-18-mdns-discovery-revamp.md
@@ -1,0 +1,92 @@
+# Replace GUI network scan discovery with mDNS and add FastAPI service advertisement
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` are maintained in line with `.agent/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this change, end users can discover Raspberry Pi devices automatically on the local LAN without entering IPs or scanning subnets. The backend publishes an IPv4 mDNS service (`_myapp._tcp.local.`), and the desktop GUI discovers that service, validates `/health`, and auto-fills configured box URLs.
+
+## Progress
+
+- [x] (2026-02-18 00:00Z) Reviewed current discovery flow (CIDR/base URL probing) and startup lifecycle in `rest_api/app.py`.
+- [x] (2026-02-18 00:10Z) Replaced discovery domain/use case contracts to mDNS-first timing-based discovery inputs.
+- [x] (2026-02-18 00:20Z) Replaced adapter implementation with Zeroconf browse + IPv4 extraction + `/health` validation.
+- [x] (2026-02-18 00:30Z) Added async GUI discovery orchestration in `DiscoveryController` and updated settings/discovery result view labels/columns.
+- [x] (2026-02-18 00:40Z) Added backend `rest_api/mdns_service.py` and integrated registration/deregistration into FastAPI lifespan.
+- [x] (2026-02-18 00:45Z) Updated docs and dependencies for Zeroconf-based discovery.
+- [ ] (2026-02-18 00:46Z) Commit changes and create PR.
+
+## Surprises & Discoveries
+
+- Observation: The original discovery controller executed synchronously and blocked the UI during probing.
+  Evidence: `seva/app/discovery_controller.py` called the use case directly from the button handler path.
+
+- Observation: Existing discovery relied on candidate URLs and derived CIDR hints from configured addresses.
+  Evidence: `_build_discovery_candidates` logic in the previous controller implementation.
+
+## Decision Log
+
+- Decision: Keep existing adapter filename (`seva/adapters/discovery_http.py`) while replacing implementation with mDNS to minimize wiring churn.
+  Rationale: Reduces integration risk and follows minimal-invasive change requirement.
+  Date/Author: 2026-02-18 / Codex
+
+- Decision: Discovery waits fixed 2.5 seconds and never exits early.
+  Rationale: Matches explicit UX requirement for fixed 2–3 second browse window.
+  Date/Author: 2026-02-18 / Codex
+
+- Decision: GUI filters by `/health` HTTP 200 only and ignores timeouts/errors silently.
+  Rationale: Matches requirement and avoids noisy UX.
+  Date/Author: 2026-02-18 / Codex
+
+## Outcomes & Retrospective
+
+The codebase now uses mDNS for both service advertisement (backend) and discovery (GUI) with IPv4-only behavior. Legacy scan/candidate construction paths were removed from active flow. Remaining completion step is commit + PR metadata.
+
+## Context and Orientation
+
+Discovery touches these modules:
+
+- `rest_api/app.py` lifespan startup/shutdown.
+- `rest_api/mdns_service.py` for backend service registration.
+- `seva/domain/discovery.py` for discovery DTO/port contracts.
+- `seva/adapters/discovery_http.py` for Zeroconf browse and health validation.
+- `seva/usecases/discover_devices.py` and `seva/usecases/discover_and_assign_devices.py` for orchestration.
+- `seva/app/discovery_controller.py` for non-blocking GUI execution.
+- `seva/app/views/settings_dialog.py` and `seva/app/views/discovery_results_dialog.py` for UI behavior.
+
+## Plan of Work
+
+Refactor from candidate-driven network scanning to fixed-window mDNS browsing by updating contracts first, then adapter and use case orchestration, then GUI controller threading/UI display, then backend startup advertisement and docs/deps.
+
+## Concrete Steps
+
+From repo root:
+
+    python -m compileall rest_api seva
+
+Expected outcome:
+
+    Compiles updated modules without syntax errors.
+
+## Validation and Acceptance
+
+Acceptance is:
+
+- Backend starts and registers `_myapp._tcp.local.` on IPv4 at port 8000, then deregisters on shutdown.
+- GUI “Geräte suchen” action does not block UI thread and performs fixed-duration discovery.
+- GUI only accepts devices with `GET /health` HTTP 200.
+- Discovery result payload includes `name`, `ip`, `port`, `health_url`, `properties`.
+
+## Idempotence and Recovery
+
+All edits are idempotent text/code changes. If runtime discovery fails in a specific environment, fallback behavior is a user-visible “no devices found” state without crashes.
+
+## Artifacts and Notes
+
+Implementation uses `zeroconf` dependency added to both `requirements.txt` and `pyproject.toml` for reproducible installs.
+
+## Interfaces and Dependencies
+
+- Added dependency: `zeroconf>=0.132`.
+- `DeviceDiscoveryPort.discover(duration_s, health_timeout_s)` returns `DiscoveredBox` records.
+- `MdnsRegistrar.register()` and `.deregister()` encapsulate backend lifecycle publication.

--- a/docs/classes_rest_api.md
+++ b/docs/classes_rest_api.md
@@ -15,10 +15,11 @@ The REST package currently contains the following Python modules:
 - `rest_api/nas.py`: SSH/rsync NAS adapter kept for SSH-based deployments.
 - `rest_api/auto_flash_linux.py`: Linux firmware flashing subprocess helper for `/firmware/flash`.
 - `rest_api/update_package.py`: package-update contract validation, async worker, lock, and audit orchestration.
+- `rest_api/mdns_service.py`: IPv4 mDNS registration helper for `_myapp._tcp.local.` service publication at startup/shutdown.
 
 ## `rest_api/app.py`
 
-`app.py` is the only HTTP surface consumed by the GUI. The route families map to adapters and usecases as follows:
+`app.py` is the only HTTP surface consumed by the GUI. It also manages process lifecycle hooks, including startup mDNS registration and shutdown deregistration via `rest_api/mdns_service.py`. The route families map to adapters and usecases as follows:
 
 - Device discovery and mode metadata:
   - GUI callers: `seva/adapters/device_rest.py`
@@ -45,7 +46,7 @@ The table below provides a practical, per-endpoint overview of method, purpose, 
 | Method | Path | Handler | Purpose | Typical caller(s) |
 |---|---|---|---|---|
 | GET | `/version` | `version_info` | Returns API/runtime/build metadata for diagnostics and support. | Manual ops checks, service introspection |
-| GET | `/health` | `health` | Basic service liveness + discovered device count. | `seva.adapters.discovery_http`, startup checks |
+| GET | `/health` | `health` | Basic service liveness + discovered device count. | `seva.adapters.discovery_http`, startup checks, mDNS post-discovery validation |
 | GET | `/devices` | `list_devices` | Enumerates discovered potentiostat slots and port metadata. | `seva.adapters.device_rest` |
 | GET | `/devices/status` | `list_device_status` | Returns slot state derived from active jobs (`idle/queued/running/...`). | GUI status polling |
 | GET | `/modes` | `list_modes` | Lists available measurement modes exposed by controller integration. | GUI mode selectors |

--- a/docs/classes_seva.md
+++ b/docs/classes_seva.md
@@ -107,10 +107,10 @@ Parameter schema mapping examples:
   - consumed by `StartRemoteUpdate` and `PollRemoteUpdate`
   - uploads `.zip` package to `POST /updates/package` and polls `GET /updates/{update_id}`
   - raises typed adapter errors from `seva/adapters/api_errors.py`
-- `discovery_http.py` (`DeviceDiscoveryPort`): implements host/base-url/CIDR discovery.
+- `discovery_http.py` (`DeviceDiscoveryPort`): implements mDNS (`_myapp._tcp.local.`) discovery.
   - consumed by `DiscoverDevices` and `DiscoverAndAssignDevices`
-  - expands CIDR ranges, probes `/version` for identity and `/health` for enrichment
-  - deduplicates discovered `base_url` values before returning domain `DiscoveredBox` objects
+  - browses Zeroconf services for a fixed duration, extracts IPv4 + TXT properties, validates `/health` (HTTP 200)
+  - returns normalized domain `DiscoveredBox` objects (`name`, `ip`, `port`, `health_url`, `properties`) with duplicate-name suffixing
 
 ### Local/test adapters
 
@@ -137,7 +137,7 @@ Parameter schema mapping examples:
 
 ### Discovery and diagnostics
 
-- `discover_devices.py`: candidate probing and registry merge helpers.
+- `discover_devices.py`: mDNS discovery invocation and registry merge helpers.
 - `discover_and_assign_devices.py`: combined discovery + assignment operation.
 - `poll_device_status.py`: per-channel status snapshots for activity UI.
 - `test_connection.py`: health + device diagnostics for a box.

--- a/docs/gui_overview_how_to_use.md
+++ b/docs/gui_overview_how_to_use.md
@@ -39,12 +39,11 @@ Open **Settings** from the toolbar.
 
 ### Boxes
 
-- Enter **Box A/B/C/D URL**.
 - Enter **API Key** (if required by your deployment).
-- Use **Test** per box to verify connectivity.
-- Use **Scan Network** to discover available devices automatically.
+- Use **Geräte suchen** to discover available devices automatically via mDNS (`_myapp._tcp.local.`).
+- Use **Test** per box to verify connectivity after discovery mapped URLs into slots.
 
-**Feature detail:** discovery is not a blind scan only. The app uses your configured box URLs as discovery candidates and also derives subnet hints (for example `/24`) from those URLs, then deduplicates the candidate list before scanning.
+**Feature detail:** discovery is fully automatic on the local LAN and runs for a fixed browse window. It does not perform IP range scanning, broadcast probing, or manual subnet hints.
 
 ### Relay box
 
@@ -90,7 +89,7 @@ When you run network discovery, this result dialog shows detected SEVA devices.
 
 ![Discovery results dialog](assets/gui/discovery_results_dialog.png)
 
-Use this to confirm that expected boxes are reachable and to validate API/build information.
+Use this to confirm discovered service name, IPv4, port, health URL, and advertised mDNS properties.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,12 +9,12 @@ For the full end-user workflow, see [GUI Overview & How to Use](gui_overview_how
 
 If device discovery returns nothing:
 
-1. Verify the REST API is running on the target device.
-2. In the GUI **Settings**, confirm the base URL/IP and port are correct.
-3. Use **Test Connection** to verify `/health` and `/devices` respond.
-4. On the Pi, ensure devices are attached and recognized by the OS.
+1. Verify the REST API is running on the Raspberry Pi target device.
+2. Verify the Pi and GUI host are in the same LAN segment (mDNS is LAN-local).
+3. On the Pi, ensure the FastAPI process started successfully and registered `_myapp._tcp.local.`.
+4. Wait for discovery to finish (fixed browse duration) and then run **Geräte suchen** again.
 
-Note: discovery uses existing configured box URLs plus derived subnet hints. If your configured URLs are outdated, discovery quality will also be poor.
+Note: GUI discovery uses mDNS only and validates each result with `GET /health` (HTTP 200 required). It does not use manual IP hints or subnet scans.
 
 ## Wrong base URL / API not reachable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "pydantic>=1.10,<3",
   "pyserial>=3.5",
   "python-multipart>=0.0.6",
+  "zeroconf>=0.132",
   "mkdocs>=1.5",
   "pyBEEP @ git+https://github.com/aurelienblanc2/Potentiostat-driver-pyBEEP.git",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ uvicorn[standard]>=0.23
 pydantic>=1.10,<3
 pyserial>=3.5
 python-multipart>=0.0.6
+zeroconf>=0.132
 
 # Potentiostat driver (pyBEEP)
 git+https://github.com/aurelienblanc2/Potentiostat-driver-pyBEEP.git#egg=pyBEEP

--- a/rest_api/mdns_service.py
+++ b/rest_api/mdns_service.py
@@ -1,0 +1,62 @@
+"""mDNS service registration for the FastAPI box API."""
+
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass
+from typing import Optional
+
+from zeroconf import IPVersion, ServiceInfo, Zeroconf
+
+SERVICE_TYPE = "_myapp._tcp.local."
+SERVICE_PORT = 8000
+
+
+@dataclass
+class MdnsRegistrar:
+    """Register and unregister the local `_myapp._tcp.local.` service."""
+
+    hostname: str
+    ip_address: str
+    port: int = SERVICE_PORT
+
+    def __post_init__(self) -> None:
+        self._zeroconf: Optional[Zeroconf] = None
+        self._service_info: Optional[ServiceInfo] = None
+
+    def register(self) -> None:
+        """Register the local service on IPv4 mDNS."""
+        service_name = f"{self.hostname}.{SERVICE_TYPE}"
+        self._service_info = ServiceInfo(
+            type_=SERVICE_TYPE,
+            name=service_name,
+            addresses=[socket.inet_aton(self.ip_address)],
+            port=self.port,
+            properties={
+                b"health": b"/health",
+                b"api": b"fastapi",
+                b"port": str(self.port).encode("utf-8"),
+            },
+            server=f"{self.hostname}.local.",
+        )
+        self._zeroconf = Zeroconf(ip_version=IPVersion.V4Only)
+        self._zeroconf.register_service(self._service_info)
+
+    def deregister(self) -> None:
+        """Cleanly deregister the mDNS service and close sockets."""
+        if self._zeroconf and self._service_info:
+            self._zeroconf.unregister_service(self._service_info)
+        if self._zeroconf:
+            self._zeroconf.close()
+        self._service_info = None
+        self._zeroconf = None
+
+
+def resolve_local_ipv4() -> str:
+    """Return the primary local IPv4 used for outbound LAN traffic."""
+    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        probe.connect(("8.8.8.8", 80))
+        return probe.getsockname()[0]
+    finally:
+        probe.close()

--- a/seva/app/discovery_controller.py
+++ b/seva/app/discovery_controller.py
@@ -1,20 +1,12 @@
-"""Controller that orchestrates network discovery from the settings dialog.
-
-This module bridges settings UI actions to discovery use-cases, then writes
-results back to the settings viewmodel and persistence adapter.
-"""
+"""Controller that orchestrates asynchronous mDNS discovery from settings UI."""
 
 from __future__ import annotations
 
-
 import logging
-from typing import List, Optional, Sequence, Set, TYPE_CHECKING
-from urllib.parse import urlparse
+import threading
+from typing import Optional, Sequence, TYPE_CHECKING
 
-from seva.usecases.discover_and_assign_devices import (
-    DiscoverAndAssignDevices,
-    DiscoveryRequest,
-)
+from seva.usecases.discover_and_assign_devices import DiscoverAndAssignDevices, DiscoveryRequest
 from seva.viewmodels.settings_vm import SettingsVM
 from seva.domain.ports import StoragePort
 from seva.app.views.discovery_results_dialog import DiscoveryResultsDialog
@@ -24,7 +16,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class DiscoveryController:
-    """Run discovery workflow and update settings state/UI."""
+    """Run device discovery workflow and update settings state/UI."""
 
     def __init__(
         self,
@@ -35,59 +27,64 @@ class DiscoveryController:
         discovery_uc: DiscoverAndAssignDevices,
         box_ids: Sequence[str],
     ) -> None:
-        """Store discovery dependencies.
-
-        Args:
-            win: Root window used for toast feedback and modal parenting.
-            settings_vm: Settings viewmodel to update with discovered URLs.
-            storage: Persistence port for user settings.
-            discovery_uc: Use-case that discovers and assigns devices.
-            box_ids: Ordered list of supported box identifiers.
-        """
         self._log = logging.getLogger(__name__)
         self.win = win
         self.settings_vm = settings_vm
         self.storage = storage
         self.discovery_uc = discovery_uc
         self.box_ids = list(box_ids)
+        self._running = False
 
     def discover(self, dialog: Optional["SettingsDialog"] = None) -> None:
-        """Execute discovery and apply results to VM, storage, and dialog.
-
-        Args:
-            dialog: Optional settings dialog to update in-place after discovery.
-        """
-        candidates = self._build_discovery_candidates()
-        if not candidates:
-            self.win.show_toast("No discovery candidates available.")
+        """Run discovery in a worker thread to keep the GUI responsive."""
+        if self._running:
             return
 
-        current_registry = {
-            key: value
-            for key, value in (self.settings_vm.api_base_urls or {}).items()
-            if value
-        }
+        self._running = True
+        self.win.show_toast("Gerätesuche läuft...")
 
-        result = self.discovery_uc(
-            DiscoveryRequest(
-                candidates=candidates,
-                api_key=None,
-                timeout_s=0.5,
-                box_ids=self.box_ids,
-                existing_registry=current_registry,
-            )
-        )
+        def worker() -> None:
+            error: Optional[Exception] = None
+            result = None
+            try:
+                current_registry = {
+                    key: value
+                    for key, value in (self.settings_vm.api_base_urls or {}).items()
+                    if value
+                }
+                result = self.discovery_uc(
+                    DiscoveryRequest(
+                        duration_s=2.5,
+                        health_timeout_s=0.6,
+                        box_ids=self.box_ids,
+                        existing_registry=current_registry,
+                    )
+                )
+            except Exception as exc:  # mapped by use case
+                error = exc
+
+            self.win.after(0, lambda: self._finish(dialog=dialog, result=result, error=error))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _finish(self, *, dialog: Optional["SettingsDialog"], result, error: Optional[Exception]) -> None:
+        """Apply discovery outcome back on GUI thread and persist settings."""
+        self._running = False
+
+        if error is not None:
+            self._log.error("Discovery failed", exc_info=(type(error), error, error.__traceback__))
+            self.win.show_toast(str(error))
+            return
+        if result is None:
+            self.win.show_toast("Discovery finished. No devices found.")
+            return
 
         persistence_error: Optional[Exception] = None
         if result.assigned:
             normalized_payload = {
                 box_id: result.normalized_registry.get(box_id, "") for box_id in self.box_ids
             }
-            try:
-                self.settings_vm.api_base_urls = normalized_payload
-            except ValueError as exc:
-                self.win.show_toast(f"Could not apply discovered devices: {exc}")
-                return
+            self.settings_vm.api_base_urls = normalized_payload
             try:
                 self.storage.save_user_settings(self.settings_vm.to_dict())
             except Exception as exc:
@@ -106,56 +103,16 @@ class DiscoveryController:
         if result.discovered:
             rows = []
             for box in result.discovered:
-                rows.append({
-                    "base_url": (getattr(box, "base_url", "") or "").strip(),
-                    "box_id": getattr(box, "box_id", None),
-                    "devices": getattr(box, "devices", None),
-                    "api_version": getattr(box, "api_version", None),
-                    "build": getattr(box, "build", None),
-                })
+                rows.append(
+                    {
+                        "name": box.name,
+                        "ip": box.ip,
+                        "port": box.port,
+                        "health_url": box.health_url,
+                        "properties": dict(box.properties),
+                    }
+                )
             DiscoveryResultsDialog(self.win, rows)
-
-    def _build_discovery_candidates(self) -> List[str]:
-        """Build ordered host/CIDR discovery candidates from known URLs.
-
-        Returns:
-            Deduplicated list of candidate URLs/subnets. Falls back to
-            ``192.168.0.0/24`` when no hints are configured.
-        """
-        candidates: List[str] = []
-        base_urls = self.settings_vm.api_base_urls or {}
-        for url in base_urls.values():
-            value = (url or "").strip()
-            if value:
-                candidates.append(value)
-
-        cidr_hints: List[str] = []
-
-        for value in candidates:
-            parsed = urlparse(value)
-            host = parsed.hostname or ""
-            if not host:
-                continue
-            octets = host.split(".")
-            if len(octets) != 4:
-                continue
-            try:
-                if all(0 <= int(part) <= 255 for part in octets):
-                    cidr_hints.append(".".join(octets[:3]) + ".0/24")
-            except ValueError:
-                continue
-
-        ordered: List[str] = []
-        seen: Set[str] = set()
-        for entry in candidates + cidr_hints:
-            normalized = entry.strip()
-            if normalized and normalized not in seen:
-                seen.add(normalized)
-                ordered.append(normalized)
-
-        if not ordered:
-            ordered.append("192.168.0.0/24")
-        return ordered
 
 
 __all__ = ["DiscoveryController"]

--- a/seva/app/views/settings_dialog.py
+++ b/seva/app/views/settings_dialog.py
@@ -122,7 +122,7 @@ class SettingsDialog(tk.Toplevel):
 
         ttk.Button(
             connection,
-            text="Scan Network",
+            text="Geräte suchen",
             command=lambda: self._safe(self._on_discover_devices),
         ).grid(row=len(self._boxes), column=0, columnspan=5, sticky="w", pady=(8, 0))
 

--- a/seva/domain/discovery.py
+++ b/seva/domain/discovery.py
@@ -1,51 +1,53 @@
-"""Discovery contracts used between discovery use cases and adapters.
+"""Discovery contracts used between use cases and infrastructure adapters.
 
-This module defines immutable records and protocol interfaces for network
-discovery. `DiscoverDevices` and `DiscoverAndAssignDevices` (use-case layer)
-call `DeviceDiscoveryPort.discover`, while adapters provide the HTTP probing
-implementation.
+The GUI discovery workflow uses mDNS/Zeroconf to find `_myapp._tcp.local.`
+services on the local LAN, then validates each candidate via HTTP `/health`.
+This module contains the adapter boundary records and typed adapter error.
 """
 
 from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional, Protocol, Sequence, List
+from typing import Mapping, Protocol, Sequence
+
+
+class DiscoveryAdapterError(Exception):
+    """Raised by discovery adapters when Zeroconf browsing fails unexpectedly."""
+
 
 @dataclass(frozen=True)
 class DiscoveredBox:
-    """Lightweight descriptor for a discovered SEVA box."""
-    base_url: str                 # e.g. "http://192.168.0.42:8000"
-    api_version: Optional[str] = None
-    build: Optional[str] = None
-    box_id: Optional[str] = None  # comes from /health
-    devices: Optional[int] = None # comes from /health
+    """Normalized discovery result consumed by use cases and controllers.
+
+    Attributes:
+        name: Human-readable service instance name (suffixed when duplicated).
+        ip: IPv4 address advertised by the discovered service.
+        port: TCP port advertised by the discovered service.
+        health_url: Full URL used for `/health` validation.
+        properties: TXT properties exposed by the mDNS service.
+    """
+
+    name: str
+    ip: str
+    port: int
+    health_url: str
+    properties: Mapping[str, str]
+
 
 class DeviceDiscoveryPort(Protocol):
-    """Port for discovering SEVA devices on the network."""
-    def discover(
-        self,
-        candidates: Sequence[str],
-        api_key: Optional[str] = None,
-        timeout_s: float = 0.3
-    ) -> List[DiscoveredBox]:
-        """Probe candidate addresses and return reachable boxes.
+    """Port for discovering SEVA devices on the local network via mDNS."""
+
+    def discover(self, *, duration_s: float = 2.5, health_timeout_s: float = 0.6) -> Sequence[DiscoveredBox]:
+        """Browse local mDNS services and return validated devices.
 
         Args:
-            candidates: Base URLs, hosts, or CIDR inputs prepared by the use case.
-            api_key: Optional API key forwarded to adapter HTTP calls.
-            timeout_s: Per-probe timeout in seconds.
+            duration_s: Total Zeroconf browse window in seconds.
+            health_timeout_s: Timeout used for validating `/health`.
 
         Returns:
-            A list of discovered boxes with optional metadata populated from
-            `/version` and `/health` probes.
+            A sequence of discovered and health-validated devices.
 
-        Side Effects:
-            Performs network I/O in adapter implementations.
-
-        Call Chain:
-            ViewModel command -> discovery use case -> DeviceDiscoveryPort adapter.
-
-        Error Cases:
-            Adapter implementations may raise typed adapter errors when probing
-            fails unexpectedly.
+        Raises:
+            DiscoveryAdapterError: When Zeroconf browse setup fails.
         """
         ...

--- a/seva/usecases/discover_devices.py
+++ b/seva/usecases/discover_devices.py
@@ -1,81 +1,45 @@
-"""Discovery-focused use cases built on `DeviceDiscoveryPort`.
+"""Discovery-focused use cases built on ``DeviceDiscoveryPort``."""
 
-`DiscoverDevices` probes candidates, while `MergeDiscoveredIntoRegistry`
-combines discovered results with existing alias-to-url mappings.
-"""
-
-# seva/usecases/discover_devices.py
 from __future__ import annotations
-from typing import Dict, List, Optional
+
+from typing import Dict, List, Sequence
+
 from seva.domain.discovery import DeviceDiscoveryPort, DiscoveredBox
 
+
 class DiscoverDevices:
-    """Use case: network scan using a discovery port."""
+    """Use case that runs mDNS discovery through a discovery port."""
 
     def __init__(self, port: DeviceDiscoveryPort):
-        """Bind the discovery adapter used for network probing.
-
-        Args:
-            port: Adapter implementing candidate probing and metadata retrieval.
-        """
         self._port = port
 
     def __call__(
         self,
         *,
-        candidates: List[str],
-        api_key: Optional[str] = None,
-        timeout_s: float = 0.3
-    ) -> List[DiscoveredBox]:
-        """Probe candidate URLs/networks and return discovered boxes.
+        duration_s: float = 2.5,
+        health_timeout_s: float = 0.6,
+    ) -> Sequence[DiscoveredBox]:
+        """Return discovered and health-validated boxes."""
+        return self._port.discover(duration_s=duration_s, health_timeout_s=health_timeout_s)
 
-        Args:
-            candidates: Candidate hosts, URLs, or CIDR ranges to probe.
-            api_key: Optional API key used by secured endpoints.
-            timeout_s: Per-probe timeout in seconds.
-
-        Returns:
-            List[DiscoveredBox]: Discovery hits enriched by the adapter.
-
-        Side Effects:
-            Performs network calls through ``DeviceDiscoveryPort.discover``.
-        """
-        return self._port.discover(candidates=candidates, api_key=api_key, timeout_s=timeout_s)
 
 class MergeDiscoveredIntoRegistry:
-    """
-    Merge discovered boxes into alias->base_url registry.
-    - Does not drop existing aliases.
-    - Adds new entries with a unique alias (prefer box_id/build; fallback to host).
-    """
+    """Merge discovered boxes into alias->base_url registry with unique aliases."""
 
     def __call__(self, *, discovered: List[DiscoveredBox], registry: Dict[str, str]) -> Dict[str, str]:
-        """Merge discovery hits into an alias registry without overwriting URLs.
-
-        Args:
-            discovered: Adapter results from ``DiscoverDevices``.
-            registry: Existing alias-to-url mapping from settings storage.
-
-        Returns:
-            Dict[str, str]: New mapping with discovered URLs added.
-
-        Side Effects:
-            None. Returns a copy and leaves ``registry`` unchanged.
-        """
-        out = dict(registry)  # copy
+        out = dict(registry)
         existing_urls = set(out.values())
 
         for box in discovered:
-            if box.base_url in existing_urls:
+            base_url = f"http://{box.ip}:{box.port}"
+            if base_url in existing_urls:
                 continue
-            # Prefer explicit identifiers, then build tag, then URL fallback.
-            alias = box.box_id or (box.build or "").strip() or box.base_url
-            alias = alias or box.base_url
+            alias = (box.name or "device").strip() or "device"
             base_alias = alias
-            i = 1
+            suffix = 2
             while alias in out:
-                i += 1
-                alias = f"{base_alias}-{i}"
-            out[alias] = box.base_url
-            existing_urls.add(box.base_url)
+                alias = f"{base_alias}-{suffix}"
+                suffix += 1
+            out[alias] = base_url
+            existing_urls.add(base_url)
         return out


### PR DESCRIPTION
### Motivation

- Replace the previous candidate/CIDR HTTP scan with a robust mDNS (Zeroconf) discovery flow so the GUI can find Raspberry Pi box APIs automatically on the LAN.  
- Ensure discovery is IPv4-only (backend advertises IPv4), requires `GET /health` -> HTTP 200 to be accepted, and handles multiple instances with identical names via suffixing.  
- Keep the UI responsive by running discovery off the main thread and remove legacy fallback scan paths.  
- Update documentation and runtime dependencies to reflect the new mDNS-only behavior.

### Description

- Changed discovery domain contract to `DiscoveredBox(name, ip, port, health_url, properties)` and introduced a typed discovery adapter error.  
- Replaced the discovery adapter with a Zeroconf-based implementation that browses `_myapp._tcp.local.` for a fixed window, extracts IPv4 + TXT properties, validates each candidate via `GET /health` (HTTP 200) and applies duplicate-name suffixing.  
- Updated use-cases (`DiscoverDevices`, `DiscoverAndAssignDevices`, merge logic) to accept `duration_s`/`health_timeout_s`, produce `http://<ip>:<port>` URLs, and merge discovered results into the settings registry.  
- Made GUI discovery non-blocking (worker thread + `after(...)` UI update), changed result dialog columns to `name, ip, port, health_url, properties`, and renamed the Settings button to "Geräte suchen".  
- Added backend mDNS registration helper (`rest_api/mdns_service.py`) and integrated IPv4-only service registration/deregistration into the FastAPI lifespan, and added `zeroconf` to runtime dependencies and docs.

### Testing

- Compiled the modified packages with `python -m compileall rest_api seva` and all updated modules compiled without syntax errors.  
- No unit/integration tests were added or executed as part of this change (per scope); documentation and dependency files were updated accordingly.  
- Quick runtime safety: the FastAPI lifespan now attempts mDNS registration at startup and deregistration on shutdown; discovery controller runs in a background thread to avoid UI blocking (observed via static inspection and successful compilation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950922e2b08331b48ad4760f507a70)